### PR TITLE
feat(all): add interrupt-driven async uart support

### DIFF
--- a/.github/workflows/Cargo.yml
+++ b/.github/workflows/Cargo.yml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_HTTP_MULTIPLEXING: false
 
 jobs:
   fmt:
@@ -57,7 +58,7 @@ jobs:
       - name: Install cargo-tarpaulin
         run: cargo install cargo-tarpaulin
       - name: Generate code coverage
-        run: cargo tarpaulin --engine llvm -p artinchip-hal --all-features --out Html --output-dir ./coverage-report
+        run: cargo tarpaulin --engine llvm -p artinchip-hal --features "d13x clic_interrupts" --out Html --output-dir ./coverage-report
       - name: Upload coverage report
         uses: actions/upload-artifact@v4
         with:
@@ -69,17 +70,34 @@ jobs:
     needs: fmt
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        PACKAGE: [artinchip-hal, artinchip-rt]
-        FEATURES: [d12x, d13x, d21x, g73x, m6800]
+        # Bind each package to its specific interrupt feature
+        PACKAGE: 
+          - name: artinchip-hal
+            int_feat: clic_interrupts
+          - name: artinchip-rt
+            int_feat: interrupts
+        CHIP_FEATURE: [d12x, d13x, d21x, g73x, m6800]
+        ENABLE_INT: [false, true] 
+        # Exclude unsupported combinations (D21x has no CLIC)
+        exclude:
+          - CHIP_FEATURE: d21x
+            ENABLE_INT: true
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: stable
+          toolchain: nightly
+          target: riscv32imac-unknown-none-elf
           components: clippy
       - name: Run cargo clippy
-        run: cargo clippy -p ${{ matrix.PACKAGE }} --all-targets --features ${{ matrix.FEATURES }} -- -D warnings
+        run: |
+          FEATURES="${{ matrix.CHIP_FEATURE }}"
+          if [ "${{ matrix.ENABLE_INT }}" = "true" ]; then
+            FEATURES="$FEATURES ${{ matrix.PACKAGE.int_feat }}"
+          fi
+          cargo clippy -p ${{ matrix.PACKAGE.name }} --target riscv32imac-unknown-none-elf --features "$FEATURES" -- -D warnings
 
   clippy-aicfwc:
      name: Clippy Check aicfwc
@@ -113,9 +131,10 @@ jobs:
     needs: fmt
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         FEATURES: [d13x]
-        EXAMPLES: [pbp-blinky, pbp-hello-world, pbp-i2c-master, pbp-boot-info, pbp-flash, pbp-dma, pbp-pwm]
+        EXAMPLES: [pbp-blinky, pbp-hello-world, pbp-i2c-master, pbp-boot-info, pbp-flash, pbp-dma, pbp-pwm, pbp-async-uart]
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,6 @@ members = [
     "examples/pbp/pbp-flash",
     "examples/pbp/pbp-dma",
     "examples/pbp/pbp-pwm",
+    "examples/pbp/pbp-async-uart",
 ]
 resolver = "3"

--- a/artinchip-hal/Cargo.toml
+++ b/artinchip-hal/Cargo.toml
@@ -13,10 +13,14 @@ uart16550 = "0.0.1"
 embedded-hal = "1.0.0"
 embedded-time = "0.12.1"
 embedded-io = "0.7.1"
-riscv = "0.15.0"
+embedded-io-async = "0.7.0"
+riscv = { version = "0.16.0", features = ["critical-section-single-hart"] }
+critical-section = "1.2.0"
+embassy-sync = "0.8.0"
 xuantie-riscv = {git = "https://github.com/rustsbi/xuantie.git", branch = "main"}
 
 [features]
+clic_interrupts = []
 d12x = []
 d13x = []
 d21x = []

--- a/artinchip-hal/src/interrupt.rs
+++ b/artinchip-hal/src/interrupt.rs
@@ -1,0 +1,3 @@
+//! Public interrupt handling API for ArtInChip SoC.
+
+pub mod clic;

--- a/artinchip-hal/src/interrupt/clic.rs
+++ b/artinchip-hal/src/interrupt/clic.rs
@@ -1,0 +1,434 @@
+//! CLIC interrupt management.
+#![allow(unsafe_op_in_unsafe_fn)]
+
+const CLIC_BASE: u32 = 0x20800000;
+
+#[inline(always)]
+fn clic() -> &'static crate::clic::RegisterBlock {
+    unsafe { &*(CLIC_BASE as *const crate::clic::RegisterBlock) }
+}
+
+/// Initialize the CLIC controller.
+///
+/// # Safety
+/// Must only be called when the CLIC peripheral is present and the
+/// memory-mapped register block is valid for the current SoC.
+pub unsafe fn clic_init() {
+    critical_section::with(|_| {
+        let clic = clic();
+        clic.cfg.modify(|v| v.enable_vector_mode().set_nlbits(8));
+        clic.mint_thresh.modify(|v| v.set_mint_thresh(0));
+    });
+}
+
+/// Enable a specific interrupt.
+///
+/// # Safety
+/// The interrupt number must refer to a valid CLIC interrupt on the current SoC.
+pub unsafe fn enable_interrupt(irq: u8) {
+    critical_section::with(|_| {
+        let clic = clic();
+        clic.interrupts[irq as usize].int_ie.modify(|v| v.enable());
+    });
+}
+
+/// Disable a specific interrupt.
+///
+/// # Safety
+/// The interrupt number must refer to a valid CLIC interrupt on the current SoC.
+pub unsafe fn disable_interrupt(irq: u8) {
+    critical_section::with(|_| {
+        let clic = clic();
+        clic.interrupts[irq as usize].int_ie.modify(|v| v.disable());
+    });
+}
+
+/// Set the level/priority for a specific interrupt.
+///
+/// # Safety
+/// The interrupt number must refer to a valid CLIC interrupt on the current SoC.
+pub unsafe fn set_priority(irq: u8, priority: u8) {
+    critical_section::with(|_| {
+        let clic = clic();
+        clic.interrupts[irq as usize].int_ctl.write(priority);
+    });
+}
+
+/// Set the attributes of a specific interrupt.
+///
+/// # Safety
+/// The interrupt number must refer to a valid CLIC interrupt on the current SoC.
+pub unsafe fn set_interrupt_attribute(irq: u8, shv: bool, trig: u8, mode: u8) {
+    critical_section::with(|_| {
+        let clic = clic();
+        clic.interrupts[irq as usize]
+            .int_attr
+            .modify(|v| v.set_hardware_vector(shv).set_trig(trig).set_mode(mode));
+    });
+}
+
+/// Clear the pending status of a specific interrupt.
+///
+/// # Safety
+/// The interrupt number must refer to a valid CLIC interrupt on the current SoC.
+pub unsafe fn clear_pending(irq: u8) {
+    critical_section::with(|_| {
+        let clic = clic();
+        clic.interrupts[irq as usize]
+            .int_ip
+            .modify(|v| v.clear_pending());
+    });
+}
+
+/// Check if a specific interrupt is currently pending.
+pub fn is_pending(irq: u8) -> bool {
+    let clic = clic();
+    clic.interrupts[irq as usize].int_ip.read().is_pending()
+}
+
+/// Generate type-level interrupt module
+#[macro_export]
+macro_rules! clic_interrupt_mod {
+    ($($irq_name:ident = $irq_num:expr),* $(,)?) => {
+        pub mod typelevel {
+            /// Common Trait for type-level interrupts
+            pub trait Interrupt {
+                const IRQ: u8;
+
+                #[inline(always)]
+                fn enable() { unsafe { $crate::interrupt::clic::enable_interrupt(Self::IRQ) } }
+
+                #[inline(always)]
+                fn disable() { unsafe { $crate::interrupt::clic::disable_interrupt(Self::IRQ) } }
+
+                #[inline(always)]
+                fn set_priority(prio: u8) { unsafe { $crate::interrupt::clic::set_priority(Self::IRQ, prio) } }
+
+                #[inline(always)]
+                fn is_pending() -> bool { $crate::interrupt::clic::is_pending(Self::IRQ) }
+
+                #[inline(always)]
+                fn clear_pending() { unsafe { $crate::interrupt::clic::clear_pending(Self::IRQ) } }
+            }
+
+            /// Drivers implement this Trait to handle interrupt logic
+            pub trait Handler<I: Interrupt> {
+                /// Function to be called when the interrupt fires.
+                /// # Safety
+                /// Must ONLY be called from the interrupt handler context.
+                unsafe fn on_interrupt();
+            }
+
+            /// Compile-time constraint: Proves the user has bound a Handler to an Interrupt.
+            ///
+            /// # Safety
+            /// Implementors must ensure the binding is valid for the selected interrupt.
+            pub unsafe trait Binding<I: Interrupt, H: Handler<I>> {}
+
+            // Generate specific ZST (Zero-Sized Type) for each hardware interrupt
+            $(
+                #[allow(non_camel_case_types)]
+                pub enum $irq_name {}
+                impl Interrupt for $irq_name {
+                    const IRQ: u8 = $irq_num;
+                }
+            )*
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! clic_bind_interrupts {
+    ($vis:vis struct $name:ident { $($irq:ident => $($handler:ty),*;)* }) => {
+        #[derive(Copy, Clone)]
+        $vis struct $name;
+
+        // #[no_mangle] and extern "C" ensure the linker can resolve it across crates.
+        #[unsafe(no_mangle)]
+        pub extern "C" fn __artinchip_dispatch_interrupt(irq_id: usize) {
+            match irq_id as u8 {
+                $(
+                    <$crate::interrupt::clic::typelevel::$irq as $crate::interrupt::clic::typelevel::Interrupt>::IRQ => {
+                        unsafe {
+                            $(
+                                <$handler as $crate::interrupt::clic::typelevel::Handler<
+                                    $crate::interrupt::clic::typelevel::$irq
+                                >>::on_interrupt();
+                            )*
+                        }
+                    }
+                )*
+                _ => {
+                    // Unregistered ghost interrupt, just ignore it. This is a safety measure to prevent unexpected behavior.
+                }
+            }
+        }
+
+        impl $name {
+            // One-click initialization for CLIC hardware and bound interrupts
+            pub unsafe fn init_clic_and_interrupts() {
+                // Import the trampoline address exposed by the RT crate
+                unsafe extern "C" { fn AlignedTrapHandler(); }
+                let trap_addr = AlignedTrapHandler as *const () as usize;
+
+                // Configure mtvec (Mode 3: CLIC)
+                ::core::arch::asm!("csrw mtvec, {}", in(reg) trap_addr | 3);
+
+                // Initialize the CLIC controller
+                $crate::interrupt::clic::clic_init();
+
+                // Automatically configure and enable each interrupt bound in the macro
+                $(
+                    let irq_num = <$crate::interrupt::clic::typelevel::$irq as $crate::interrupt::clic::typelevel::Interrupt>::IRQ;
+                    // Default configuration: Max priority(255), Software dispatch(shv=false), Level-triggered(0)
+                    $crate::interrupt::clic::set_priority(irq_num, 255);
+                    $crate::interrupt::clic::set_interrupt_attribute(irq_num, false, 0, 3);
+                    $crate::interrupt::clic::enable_interrupt(irq_num);
+                )*
+
+                // Finally, enable global CPU interrupts
+                ::riscv::interrupt::enable();
+            }
+        }
+
+        // Apply Binding Trait constraints for each handler
+        $(
+            $(
+                unsafe impl $crate::interrupt::clic::typelevel::Binding<
+                    $crate::interrupt::clic::typelevel::$irq,
+                    $handler
+                > for $name {}
+            )* )*
+    };
+}
+
+#[cfg(feature = "d12x")]
+clic_interrupt_mod! {
+    CPU_TIMER = 7,
+    DCE = 31,
+    DMA = 32,
+    SPI_ENC = 41,
+    QSPI0 = 44,
+    QSPI1 = 45,
+    SDMC0 = 46,
+    SDMC1 = 47,
+    XSPI = 49,
+    RTC = 50,
+    MTOP = 51,
+    AUDIO = 54,
+    LCD = 55,
+    DE = 59,
+    GE = 60,
+    VE = 61,
+    WDOG = 64,
+    GPIO_GRP_A = 68,
+    GPIO_GRP_B = 69,
+    GPIO_GRP_C = 70,
+    GPIO_GRP_D = 71,
+    GPIO_GRP_E = 72,
+    UART0 = 76,
+    UART1 = 77,
+    UART2 = 78,
+    UART3 = 79,
+    I2C0 = 84,
+    I2C1 = 85,
+    CAN0 = 88,
+    CAN1 = 89,
+    PWM = 90,
+    GPAI = 92,
+    RTP = 93,
+    THS = 94,
+    CIR = 95,
+}
+
+#[cfg(feature = "d13x")]
+clic_interrupt_mod! {
+    CPU_TIMER = 7,
+    SYSCFG = 16,
+    CPM = 20,
+    SDFM = 21,
+    HCL = 22,
+    CORDIC = 23,
+    PWMCS_FAULT = 24,
+    PWMCS_EPWM = 25,
+    PWMCS_CAP = 26,
+    PWMCS_QEP = 27,
+    PSADC = 28,
+    PWMCS_QOUT = 29,
+    DMA = 32,
+    CE = 33,
+    USB_DEV = 34,
+    USB_HOST0_EHCI = 35,
+    USB_HOST0_OHCI = 36,
+    GMAC = 39,
+    SPI_ENC = 41,
+    QSPI2 = 42,
+    QSPI3 = 43,
+    QSPI0 = 44,
+    QSPI1 = 45,
+    SDMC0 = 46,
+    SDMC1 = 47,
+    XSPI = 49,
+    RTC = 50,
+    MTOP = 51,
+    I2S = 52,
+    AUDIO = 54,
+    LCD = 55,
+    DSI = 56,
+    DVP = 57,
+    DE = 59,
+    GE = 60,
+    VE = 61,
+    WDOG = 64,
+    GPIO_GRP_A = 68,
+    GPIO_GRP_B = 69,
+    GPIO_GRP_C = 70,
+    GPIO_GRP_D = 71,
+    GPIO_GRP_E = 72,
+    UART0 = 76,
+    UART1 = 77,
+    UART2 = 78,
+    UART3 = 79,
+    UART4 = 80,
+    UART5 = 81,
+    UART6 = 82,
+    UART7 = 83,
+    I2C0 = 84,
+    I2C1 = 85,
+    I2C2 = 86,
+    CAN0 = 88,
+    CAN1 = 89,
+    PWM = 90,
+    GPAI = 92,
+    RTP = 93,
+    THS = 94,
+    CIR = 95,
+    TA0_IF = 104,
+    TA1_IF = 105,
+    EDAT0_IF = 106,
+    EDAT1_IF = 107,
+    BIS0_IF = 108,
+    BIS_IF = 109,
+}
+
+#[cfg(feature = "g73x")]
+clic_interrupt_mod! {
+    CPU_TIMER = 7,
+    SYSCFG = 16,
+    CPM = 20,
+    SDFM = 21,
+    HCL = 22,
+    CORDIC = 23,
+    PWMCS_FAULT = 24,
+    PWMCS_PWMCS = 25,
+    PWMCS_CAP = 26,
+    PWMCS_QEP = 27,
+    PSADC = 28,
+    PWMCS_QOUT = 29,
+    DMA = 32,
+    CE = 33,
+    USB_DEV = 34,
+    USB_HOST0_EHCI = 35,
+    USB_HOST0_OHCI = 36,
+    GMAC = 39,
+    SPI_ENC = 41,
+    QSPI2 = 42,
+    QSPI3 = 43,
+    QSPI0 = 44,
+    QSPI1 = 45,
+    SDMC0 = 46,
+    SDMC1 = 47,
+    XSPI = 49,
+    RTC = 50,
+    MTOP = 51,
+    I2S = 52,
+    AUDIO = 54,
+    LCD = 55,
+    DSI = 56,
+    DVP = 57,
+    DE = 59,
+    GE = 60,
+    VE = 61,
+    WDOG = 64,
+    GPIO_GRP_A = 68,
+    GPIO_GRP_B = 69,
+    GPIO_GRP_C = 70,
+    GPIO_GRP_D = 71,
+    GPIO_GRP_E = 72,
+    UART0 = 76,
+    UART1 = 77,
+    UART2 = 78,
+    UART3 = 79,
+    UART4 = 80,
+    UART5 = 81,
+    UART6 = 82,
+    UART7 = 83,
+    I2C0 = 84,
+    I2C1 = 85,
+    I2C2 = 86,
+    CAN0 = 88,
+    CAN1 = 89,
+    PWM = 90,
+    GPAI = 92,
+    RTP = 93,
+    THS = 94,
+    CIR = 95,
+    TA0_IF = 104,
+    TA1_IF = 105,
+    EDT0_IF = 106,
+    EDT1_IF = 107,
+    BISS0_IF = 108,
+    BISS_IF = 109,
+}
+
+#[cfg(feature = "m6800")]
+clic_interrupt_mod! {
+    CPU_TIMER = 7,
+    SYSCFG = 16,
+    CPM = 20,
+    SDFM = 21,
+    HCL = 22,
+    CORDIC = 23,
+    EPWM_FAULT = 24,
+    EPWM = 25,
+    CAP = 26,
+    QEP = 27,
+    ADC = 28,
+    QOUT = 29,
+    DMA = 32,
+    CE = 33,
+    USB_DEV = 34,
+    EMAC = 39,
+    SPI_ENC = 41,
+    QSPI2 = 42,
+    QSPI3 = 43,
+    QSPI0 = 44,
+    QSPI1 = 45,
+    WDOG = 64,
+    GPIO_GRP_A = 68,
+    GPIO_GRP_B = 69,
+    GPIO_GRP_C = 70,
+    GPIO_GRP_D = 71,
+    GPIO_GRP_E = 72,
+    UART0 = 76,
+    UART1 = 77,
+    UART2 = 78,
+    UART3 = 79,
+    UART4 = 80,
+    UART5 = 81,
+    UART6 = 82,
+    UART7 = 83,
+    I2C0 = 84,
+    I2C1 = 85,
+    I2C2 = 86,
+    CAN0 = 88,
+    CAN1 = 89,
+    PWM = 90,
+    THS = 94,
+    TA0_IF = 104,
+    TA1_IF = 105,
+    EDAT0_IF = 106,
+    EDAT1_IF = 107,
+    BIS0_IF = 108,
+    BIS_IF = 109,
+}

--- a/artinchip-hal/src/lib.rs
+++ b/artinchip-hal/src/lib.rs
@@ -10,6 +10,8 @@ pub mod dma;
 pub mod gpio;
 pub mod gtc;
 pub mod i2c;
+#[cfg(feature = "clic_interrupts")]
+pub mod interrupt;
 pub mod pad;
 pub mod pwm;
 pub mod qspi;
@@ -18,6 +20,7 @@ pub mod sdmc;
 pub mod sid;
 pub mod spi_enc;
 pub mod sys_cfg;
+pub mod types;
 pub mod uart;
 pub mod wdog;
 pub mod wri;

--- a/artinchip-hal/src/types.rs
+++ b/artinchip-hal/src/types.rs
@@ -1,0 +1,5 @@
+//! Some shared types.
+
+mod ring_buffer;
+
+pub use ring_buffer::RingBuffer;

--- a/artinchip-hal/src/types/ring_buffer.rs
+++ b/artinchip-hal/src/types/ring_buffer.rs
@@ -1,0 +1,92 @@
+//! Generic ring buffer.
+
+use core::mem::MaybeUninit;
+
+/// A generic, fixed-size ring buffer suitable for `no_std` environments.
+/// Can store any type `T` without requiring `Copy` or `Default` bounds.
+pub struct RingBuffer<T, const N: usize> {
+    buf: [MaybeUninit<T>; N],
+    head: usize,
+    tail: usize,
+    full: bool,
+}
+
+// Ensure the buffer can be safely sent across threads if T is Send
+unsafe impl<T: Send, const N: usize> Send for RingBuffer<T, N> {}
+
+impl<T, const N: usize> RingBuffer<T, N> {
+    /// Create a new empty ring buffer.
+    pub const fn new() -> Self {
+        Self {
+            // Safely initialize an array of uninitialized memory.
+            // This is sound because the array elements are `MaybeUninit<T>`,
+            // which explicitly do not require initialization.
+            buf: unsafe { MaybeUninit::uninit().assume_init() },
+            head: 0,
+            tail: 0,
+            full: false,
+        }
+    }
+
+    /// Check if the buffer is empty.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.head == self.tail && !self.full
+    }
+
+    /// Check if the buffer is full.
+    #[inline]
+    pub fn is_full(&self) -> bool {
+        self.full
+    }
+
+    /// Push an item into the buffer.
+    /// Returns `Err(item)` if the buffer is full, giving ownership back to the caller.
+    #[inline]
+    pub fn push(&mut self, item: T) -> Result<(), T> {
+        if self.full {
+            return Err(item); // Return the item to avoid dropping it unintentionally
+        }
+
+        // Write the item into the uninitialized memory slot
+        self.buf[self.head].write(item);
+        self.head = (self.head + 1) % N;
+
+        if self.head == self.tail {
+            self.full = true;
+        }
+
+        Ok(())
+    }
+
+    /// Pop an item from the buffer.
+    /// Returns `None` if the buffer is empty.
+    #[inline]
+    pub fn pop(&mut self) -> Option<T> {
+        if self.is_empty() {
+            return None;
+        }
+
+        // Extract the value and take ownership of the memory slot
+        let item = unsafe { self.buf[self.tail].assume_init_read() };
+        self.tail = (self.tail + 1) % N;
+        self.full = false;
+
+        Some(item)
+    }
+}
+
+impl<T, const N: usize> Default for RingBuffer<T, N> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Drop implementation to ensure elements remaining in the buffer are correctly
+/// destroyed when the RingBuffer goes out of scope.
+impl<T, const N: usize> Drop for RingBuffer<T, N> {
+    fn drop(&mut self) {
+        // Pop and drop all remaining valid elements
+        while self.pop().is_some() {}
+    }
+}

--- a/artinchip-hal/src/uart.rs
+++ b/artinchip-hal/src/uart.rs
@@ -3,12 +3,16 @@
 mod blocking;
 mod config;
 mod instance;
+#[cfg(feature = "clic_interrupts")]
+mod non_blocking;
 mod pad;
 mod register;
 mod uart_ext;
 
 pub use config::*;
 pub use instance::Uart;
+#[cfg(feature = "clic_interrupts")]
+pub use non_blocking::*;
 pub use pad::*;
 pub use register::*;
 pub use uart_ext::UartExt;

--- a/artinchip-hal/src/uart/instance.rs
+++ b/artinchip-hal/src/uart/instance.rs
@@ -7,6 +7,43 @@ use super::register::RegisterBlock;
 use super::uart_ext::UartExt;
 use crate::cmu::Cmu;
 use core::marker::PhantomData;
+#[cfg(feature = "clic_interrupts")]
+use {super::non_blocking::*, crate::interrupt::clic::typelevel};
+
+/// Trait to map const generic I to its interrupt type (used for compile-time safety).
+#[cfg(feature = "clic_interrupts")]
+pub trait UartInterrupt<const I: u8> {
+    type Interrupt: typelevel::Interrupt;
+}
+
+// Macro to quickly map instance numbers to interrupt types
+#[cfg(feature = "clic_interrupts")]
+macro_rules! impl_uart_interrupts {
+    ( $( ($inst:literal, $irq_type:ident) ),* $(,)? ) => {
+        $(
+            impl UartInterrupt<$inst> for Uart<$inst> {
+                type Interrupt = crate::interrupt::clic::typelevel::$irq_type;
+            }
+        )*
+    };
+}
+
+// Macro to quickly map instance numbers to interrupt types
+#[cfg(feature = "clic_interrupts")]
+impl_uart_interrupts! {
+    (0, UART0),
+    (1, UART1),
+    (2, UART2),
+    (3, UART3),
+}
+#[cfg(feature = "clic_interrupts")]
+#[cfg(not(feature = "d12x"))]
+impl_uart_interrupts! {
+    (4, UART4),
+    (5, UART5),
+    (6, UART6),
+    (7, UART7),
+}
 
 /// UART with statically known instance number.
 pub struct Uart<const I: u8> {
@@ -27,6 +64,15 @@ impl<const I: u8> Uart<I> {
     pub const fn register_block(&self) -> &'static RegisterBlock {
         unsafe { &*self.reg }
     }
+
+    /// Get register block for a specific index (used by Interrupt Handler).
+    #[cfg(feature = "clic_interrupts")]
+    #[inline(always)]
+    pub(crate) unsafe fn regs_at_index() -> &'static RegisterBlock {
+        let base_addr = 0x18710000 + (I as usize) * 0x1000;
+
+        unsafe { &*(base_addr as *const RegisterBlock) }
+    }
 }
 
 impl<const I: u8> UartExt<'static, I> for Uart<I> {
@@ -43,5 +89,29 @@ impl<const I: u8> UartExt<'static, I> for Uart<I> {
         RX: UartPad<I> + Receive<I>,
     {
         BlockingSerial::new(self.register_block(), tx, rx, config, cmu)
+    }
+    #[cfg(feature = "clic_interrupts")]
+    #[inline]
+    fn new_async<TX, RX, IRQS>(
+        self,
+        tx: TX,
+        rx: RX,
+        config: UartConfig,
+        cmu: &mut Cmu,
+        _irqs: IRQS,
+    ) -> AsyncSerial<'static, I, TX, RX>
+    where
+        Self: Sized + UartInterrupt<I>,
+        TX: UartPad<I> + Transmit<I>,
+        RX: UartPad<I> + Receive<I>,
+        Uart<I>: UartInterrupt<I>,
+        AsyncUartHandler<I>:
+            crate::interrupt::clic::typelevel::Handler<<Uart<I> as UartInterrupt<I>>::Interrupt>,
+        IRQS: crate::interrupt::clic::typelevel::Binding<
+                <Uart<I> as UartInterrupt<I>>::Interrupt,
+                AsyncUartHandler<I>,
+            >,
+    {
+        AsyncSerial::new(self.register_block(), tx, rx, config, cmu)
     }
 }

--- a/artinchip-hal/src/uart/non_blocking.rs
+++ b/artinchip-hal/src/uart/non_blocking.rs
@@ -1,0 +1,298 @@
+//! Async serial communication interface.
+
+use core::cell::RefCell;
+use core::future::poll_fn;
+use core::task::Poll;
+
+use critical_section::Mutex;
+use embassy_sync::waitqueue::AtomicWaker;
+use uart16550::{PendingInterrupt, TriggerLevel};
+
+use super::config::{StopBits, UartConfig};
+use super::instance::{Uart, UartInterrupt};
+use super::pad::{Receive, Transmit, UartPad};
+use super::register::RegisterBlock;
+use crate::cmu::Cmu;
+use crate::interrupt::clic::typelevel::{self, Interrupt as _};
+use crate::types::RingBuffer;
+
+const RX_BUF_SIZE: usize = 256;
+const TX_BUF_SIZE: usize = 256;
+const TX_BUSY_SPIN_LIMIT: usize = 200_000;
+
+pub struct AsyncState {
+    pub rx_waker: AtomicWaker,
+    pub tx_waker: AtomicWaker,
+    pub rx_buffer: Mutex<RefCell<RingBuffer<u8, RX_BUF_SIZE>>>,
+    pub tx_buffer: Mutex<RefCell<RingBuffer<u8, TX_BUF_SIZE>>>,
+}
+
+impl AsyncState {
+    pub const fn new() -> Self {
+        Self {
+            rx_waker: AtomicWaker::new(),
+            tx_waker: AtomicWaker::new(),
+            rx_buffer: Mutex::new(RefCell::new(RingBuffer::new())),
+            tx_buffer: Mutex::new(RefCell::new(RingBuffer::new())),
+        }
+    }
+}
+
+impl Default for AsyncState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Global array holding the state for up to 8 UART instances.
+pub static UART_STATES: [AsyncState; 8] = [
+    AsyncState::new(),
+    AsyncState::new(),
+    AsyncState::new(),
+    AsyncState::new(),
+    AsyncState::new(),
+    AsyncState::new(),
+    AsyncState::new(),
+    AsyncState::new(),
+];
+
+#[inline]
+fn kick_tx_if_idle(reg: &RegisterBlock, state: &AsyncState) {
+    // Just peek into the buffer to see if there's any data
+    let has_data = critical_section::with(|cs| !state.tx_buffer.borrow_ref(cs).is_empty());
+
+    if !has_data {
+        return;
+    }
+
+    let uart16550 = &reg.uart16550;
+    critical_section::with(|_| {
+        let ier = uart16550.ier().read();
+        if !ier.thre_enabled() {
+            // CPU will immediately receive an interrupt,
+            // and jump to `on_interrupt` to handle the data in the buffer.
+            uart16550.ier().write(ier.enable_thre());
+        }
+    });
+}
+
+pub struct AsyncUartHandler<const I: u8>;
+
+impl<const I: u8> typelevel::Handler<<Uart<I> as UartInterrupt<I>>::Interrupt>
+    for AsyncUartHandler<I>
+where
+    Uart<I>: UartInterrupt<I>,
+{
+    unsafe fn on_interrupt() {
+        let reg = unsafe { Uart::<I>::regs_at_index() };
+        let uart16550 = &reg.uart16550;
+        let state = &UART_STATES[I as usize];
+
+        let iir = uart16550.iir_fcr().read();
+        let pending = match iir.pending_interrupts() {
+            Some(p) => p,
+            None => {
+                <Uart<I> as UartInterrupt<I>>::Interrupt::clear_pending();
+                return;
+            }
+        };
+
+        match pending {
+            PendingInterrupt::TransmitterHoldingRegisterEmpty => {
+                let byte = critical_section::with(|cs| state.tx_buffer.borrow_ref_mut(cs).pop());
+                if let Some(byte) = byte {
+                    let mut spins = 0;
+                    while reg.usr.read().is_busy() {
+                        core::hint::spin_loop();
+                        spins += 1;
+                        if spins >= TX_BUSY_SPIN_LIMIT {
+                            break;
+                        }
+                    }
+                    reg.uart16550.rbr_thr().tx_data(byte);
+                } else {
+                    critical_section::with(|_| {
+                        // FIFO is empty, must disable THRE interrupt to avoid infinite interrupt storm
+                        let ier = uart16550.ier().read();
+                        uart16550.ier().write(ier.disable_thre());
+                    });
+                    state.tx_waker.wake();
+                }
+            }
+            PendingInterrupt::ReceivedDataAvailable | PendingInterrupt::ReceivedDataTimeout => {
+                critical_section::with(|cs| {
+                    let mut rx_buf = state.rx_buffer.borrow_ref_mut(cs);
+                    while uart16550.lsr().read().is_data_ready() {
+                        rx_buf.push(uart16550.rbr_thr().rx_data()).ok();
+                    }
+                });
+                state.rx_waker.wake();
+            }
+            _ => {}
+        }
+
+        <Uart<I> as UartInterrupt<I>>::Interrupt::clear_pending();
+    }
+}
+
+pub struct AsyncSerial<'a, const I: u8, TX, RX>
+where
+    TX: UartPad<I> + Transmit<I>,
+    RX: UartPad<I> + Receive<I>,
+    Uart<I>: UartInterrupt<I>,
+{
+    pub reg: &'a RegisterBlock,
+    _tx: TX,
+    _rx: RX,
+}
+
+impl<'a, const I: u8, TX, RX> AsyncSerial<'a, I, TX, RX>
+where
+    TX: UartPad<I> + Transmit<I>,
+    RX: UartPad<I> + Receive<I>,
+    Uart<I>: UartInterrupt<I>,
+{
+    pub fn new(reg: &'a RegisterBlock, tx: TX, rx: RX, config: UartConfig, cmu: &mut Cmu) -> Self {
+        // Enable clocks for the UART instance
+        let fix_mod_clk_rate = 48_000_000;
+        let fix_mod_div = 24;
+        let clk = cmu.register_block();
+        let uart_clk = match I {
+            0 => &clk.clock_uart0,
+            1 => &clk.clock_uart1,
+            2 => &clk.clock_uart2,
+            3 => &clk.clock_uart3,
+            4 => &clk.clock_uart4,
+            5 => &clk.clock_uart5,
+            6 => &clk.clock_uart6,
+            7 => &clk.clock_uart7,
+            _ => panic!("Invalid UART index"),
+        };
+        unsafe {
+            // Initialize module clock.
+            uart_clk.modify(|v| v.set_module_clk_div(fix_mod_div).enable_module_clk());
+            uart_clk.modify(|v| v.enable_bus_clk());
+            uart_clk.modify(|v| v.enable_module_reset());
+            riscv::asm::delay(500);
+            uart_clk.modify(|v| v.disable_module_reset());
+        }
+
+        // Parse configuration
+        let baud_rate = config.baud_rate.0;
+        let data_bits = config.data_bits;
+        let stop_bits = config.stop_bits;
+        let parity = config.parity;
+
+        // Halt uart for configuration
+        unsafe {
+            reg.halt.modify(|v| v.set_halt_change_config_at_busy(true));
+        }
+
+        // Disable all interrupts
+        let uart16550 = &reg.uart16550;
+        let interrupt_types = uart16550.ier().read();
+        uart16550.ier().write(
+            interrupt_types
+                .disable_ms()
+                .disable_rda()
+                .disable_rls()
+                .disable_thre(),
+        );
+
+        // Write baud rate divisor
+        let uart_divisor = fix_mod_clk_rate / (16 * baud_rate);
+        uart16550.write_divisor(uart_divisor as u16);
+
+        // Update HALT register to apply configuration
+        unsafe {
+            reg.halt.modify(|v| v.set_halt_change_update(true));
+        }
+
+        // Configure line control register
+        let lcr = uart16550.lcr().read();
+        uart16550.lcr().write(
+            lcr.set_char_len(data_bits.to_char_len())
+                .set_one_stop_bit(stop_bits == StopBits::One)
+                .set_parity(parity.to_parity()),
+        );
+
+        // Enable FIFO and set trigger levels
+        uart16550.iir_fcr().write(TriggerLevel::_14.and_reset());
+        Self {
+            reg,
+            _tx: tx,
+            _rx: rx,
+        }
+    }
+}
+
+impl<'a, const I: u8, TX, RX> embedded_io_async::ErrorType for AsyncSerial<'a, I, TX, RX>
+where
+    TX: UartPad<I> + Transmit<I>,
+    RX: UartPad<I> + Receive<I>,
+    Uart<I>: UartInterrupt<I>,
+{
+    type Error = core::convert::Infallible;
+}
+
+impl<'a, const I: u8, TX, RX> embedded_io_async::Write for AsyncSerial<'a, I, TX, RX>
+where
+    TX: UartPad<I> + Transmit<I>,
+    RX: UartPad<I> + Receive<I>,
+    Uart<I>: UartInterrupt<I>,
+{
+    async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+        let state = &UART_STATES[I as usize];
+
+        let written = critical_section::with(|cs| {
+            let mut tx_buf = state.tx_buffer.borrow_ref_mut(cs);
+            let mut w = 0;
+            for &b in buf {
+                if tx_buf.push(b).is_ok() {
+                    w += 1;
+                } else {
+                    break;
+                }
+            }
+            w
+        });
+
+        // Kick once to avoid relying solely on THRE edge, which may cause await to hang occasionally.
+        kick_tx_if_idle(self.reg, state);
+
+        Ok(written)
+    }
+
+    async fn flush(&mut self) -> Result<(), Self::Error> {
+        let state = &UART_STATES[I as usize];
+        let reg = self.reg;
+
+        // Kick once to ensure data transfer starts even if interrupt chain is not established.
+        kick_tx_if_idle(self.reg, state);
+
+        // Async wait: let the interrupt handler empty the RAM buffer (tx_buffer)
+        poll_fn(|cx| {
+            state.tx_waker.register(cx.waker());
+
+            // If the interrupt does not continue to trigger, but the hardware FIFO is empty, actively kick again.
+            kick_tx_if_idle(self.reg, state);
+
+            let tx_empty = critical_section::with(|cs| state.tx_buffer.borrow_ref(cs).is_empty());
+            if tx_empty {
+                Poll::Ready(Ok::<(), Self::Error>(()))
+            } else {
+                // Wake the task to ensure it gets polled again, in case the interrupt was missed.
+                cx.waker().wake_by_ref();
+                Poll::Pending
+            }
+        })
+        .await?;
+
+        // Sync wait: RAM is empty, wait for the underlying hardware to physically send out the last bit of data
+        while reg.usr.read().is_busy() {
+            core::hint::spin_loop();
+        }
+
+        Ok(())
+    }
+}

--- a/artinchip-hal/src/uart/uart_ext.rs
+++ b/artinchip-hal/src/uart/uart_ext.rs
@@ -5,6 +5,8 @@ use super::config::UartConfig;
 use super::pad::UartPad;
 use super::pad::{Receive, Transmit};
 use crate::cmu::Cmu;
+#[cfg(feature = "clic_interrupts")]
+use {super::instance::*, super::non_blocking::*, crate::interrupt::clic::typelevel};
 
 pub trait UartExt<'a, const I: u8> {
     /// Greats a blocking UART interface with the specified pads.
@@ -18,4 +20,21 @@ pub trait UartExt<'a, const I: u8> {
     where
         TX: UartPad<I> + Transmit<I>,
         RX: UartPad<I> + Receive<I>;
+    /// Creates a non-blocking UART interface with the specified pads.
+    #[cfg(feature = "clic_interrupts")]
+    fn new_async<TX, RX, IRQS>(
+        self,
+        tx: TX,
+        rx: RX,
+        config: UartConfig,
+        cmu: &mut Cmu,
+        _irqs: IRQS,
+    ) -> AsyncSerial<'a, I, TX, RX>
+    where
+        Self: Sized + UartInterrupt<I>,
+        TX: UartPad<I> + Transmit<I>,
+        RX: UartPad<I> + Receive<I>,
+        Uart<I>: UartInterrupt<I>,
+        AsyncUartHandler<I>: typelevel::Handler<<Uart<I> as UartInterrupt<I>>::Interrupt>,
+        IRQS: typelevel::Binding<<Uart<I> as UartInterrupt<I>>::Interrupt, AsyncUartHandler<I>>;
 }

--- a/artinchip-rt/Cargo.toml
+++ b/artinchip-rt/Cargo.toml
@@ -15,6 +15,7 @@ paste = "1.0"
 xuantie-riscv = { git = "https://github.com/rustsbi/xuantie.git", branch = "main" }
 
 [features]
+interrupts = []
 d12x = []
 d13x = []
 d21x = []

--- a/artinchip-rt/src/core.rs
+++ b/artinchip-rt/src/core.rs
@@ -1,1 +1,2 @@
 pub mod cache;
+pub mod trap;

--- a/artinchip-rt/src/core/trap.rs
+++ b/artinchip-rt/src/core/trap.rs
@@ -1,0 +1,53 @@
+//! ArtInChip RT Trap Handler.
+
+use core::arch::global_asm;
+
+// 64-byte aligned trampoline for hardware vectoring requirement
+global_asm!(
+    "
+    .align 6
+    .global AlignedTrapHandler
+    AlignedTrapHandler:
+        j DefaultTrapHandler
+    "
+);
+
+// Only look for the external dispatcher if the interrupts feature is active
+#[cfg(feature = "interrupts")]
+unsafe extern "C" {
+    unsafe fn __artinchip_dispatch_interrupt(irq_id: usize);
+}
+
+/// The default trap handler for Machine Mode (M-Mode).
+///
+/// # Safety
+///
+/// This function must only be invoked by the hardware trap mechanism.
+/// It relies on the `"riscv-interrupt-m"` ABI to automatically save and
+/// restore the context (registers) before and after execution.
+#[unsafe(no_mangle)]
+pub unsafe extern "riscv-interrupt-m" fn DefaultTrapHandler() {
+    let mcause: usize;
+    unsafe {
+        core::arch::asm!("csrr {}, mcause", out(reg) mcause);
+    }
+
+    let is_interrupt = (mcause as isize) < 0;
+
+    if is_interrupt {
+        // Pass to the user's dispatcher
+        #[cfg(feature = "interrupts")]
+        unsafe {
+            __artinchip_dispatch_interrupt(mcause & 0xFFF);
+        }
+
+        // If a hardware interrupt somehow fires while the feature
+        // is off, safely catch it in a spin loop to prevent unpredictable behavior.
+        #[cfg(not(feature = "interrupts"))]
+        loop {
+            core::hint::spin_loop();
+        }
+    } else {
+        panic!("Hardware Exception Fatal Error! mcause: {:#X}", mcause);
+    }
+}

--- a/artinchip-rt/src/lib.rs
+++ b/artinchip-rt/src/lib.rs
@@ -1,5 +1,6 @@
 //! Bare-metal ROM runtime for ArtInChip chips.
 #![no_std]
+#![feature(abi_riscv_interrupt)]
 
 pub use artinchip_rt_macros::pbp_entry;
 

--- a/examples/pbp/pbp-async-uart/Cargo.toml
+++ b/examples/pbp/pbp-async-uart/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "pbp-async-uart"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+panic-halt = "1.0.0"
+embedded-io = "0.7.1"
+embedded-io-async = "0.7.0"
+embassy-futures = "0.1.1"
+critical-section = "1.2.0"
+riscv = { version = "0.16.0", features = ["critical-section-single-hart"] }
+heapless = "0.8"
+artinchip-hal = { version = "0.0.0", path = "../../../artinchip-hal" }
+artinchip-rt = { version = "0.0.0", path = "../../../artinchip-rt" }
+
+[features]
+default = ["d13x", "artinchip-rt/interrupts", "artinchip-hal/clic_interrupts"]
+d13x = ["artinchip-rt/d13x", "artinchip-hal/d13x"]
+# TODO other features for all the chips.

--- a/examples/pbp/pbp-async-uart/README.md
+++ b/examples/pbp/pbp-async-uart/README.md
@@ -1,0 +1,13 @@
+# PBP Async Uart
+
+## Build
+
+```
+cargo build -p pbp-async-uart --target riscv32imac-unknown-none-elf --release
+rust-objcopy -O binary target/riscv32imac-unknown-none-elf/release/pbp-async-uart target/riscv32imac-unknown-none-elf/release/pbp-async-uart.bin
+cargo run -p aicfwc -- target/riscv32imac-unknown-none-elf/release/pbp-async-uart.bin --pbp -o target/riscv32imac-unknown-none-elf/release/pbp-async-uart.pbp
+```
+
+Your PBP file will be ready at `target/riscv32imac-unknown-none-elf/release/pbp-async-uart.pbp`.
+
+Packed PBP image will be ready at the same path but with `.pk_pbp` extension.

--- a/examples/pbp/pbp-async-uart/build.rs
+++ b/examples/pbp/pbp-async-uart/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo:rustc-link-arg=-Tartinchip-rt.ld");
+}

--- a/examples/pbp/pbp-async-uart/src/main.rs
+++ b/examples/pbp/pbp-async-uart/src/main.rs
@@ -1,0 +1,73 @@
+#![no_std]
+#![no_main]
+
+use artinchip_hal::clic_bind_interrupts;
+use artinchip_hal::prelude::*;
+use artinchip_hal::uart::*;
+use artinchip_rt::{Peripherals, pbp_entry};
+use core::fmt::Write as _;
+use embassy_futures::block_on;
+use embedded_io_async::Write as _;
+use heapless::String;
+use panic_halt as _;
+
+clic_bind_interrupts!(struct Irqs {
+    UART0 => AsyncUartHandler<0>;
+});
+
+const TEST_MSG: &str = r#"die Ruinenstadt ist immer noch schön
+ich warte lange Zeit auf deine Rückkehr
+in der Hand ein Vergissmeinnicht
+
+Sand wirbelt in die Höhe
+schwarzer Wind und roter Stern
+verblasste Blütenblätter
+legen sich auf die Erde
+
+Asche wirbelt in die Höhe
+verwelkte Blütenblätter
+werden wieder zur Erde
+βίος
+
+Regentropfen sind meine Tränen
+Wind ist mein Atem und mein Erzählung
+Zweige und Blätter sind meine Hände
+denn mein Körper ist in Wurzeln gehüllt
+
+wenn die Jahreszeit des Tauens kommt
+werde ich wach und singe ein Lied
+das Vergissmeinnicht, das du mir gegeben hast, ist hier"#;
+
+#[pbp_entry]
+fn pbp_main(_boot_param: u32, _private_data: &[u8]) {
+    let mut p = Peripherals::take();
+
+    unsafe {
+        Irqs::init_clic_and_interrupts();
+    }
+
+    let uart0_tx = p.gpioa.pa0.into_uart0_tx();
+    let uart0_rx = p.gpioa.pa1.into_uart0_rx();
+    let mut uart0_async =
+        p.uart0
+            .new_async(uart0_tx, uart0_rx, UartConfig::default(), &mut p.cmu, Irqs);
+
+    block_on(async {
+        let mut buf: String<128> = String::new();
+
+        writeln!(buf, "Welcome to pbp async uart example by artinchip-hal🦀!").ok();
+        uart0_async.write_all(buf.as_bytes()).await.ok();
+
+        buf.clear();
+        writeln!(buf, "The following is a test message sent via async UART.").ok();
+        uart0_async.write_all(buf.as_bytes()).await.ok();
+
+        uart0_async.write_all(TEST_MSG.as_bytes()).await.ok();
+
+        uart0_async.flush().await.ok();
+    });
+
+    loop {
+        core::hint::spin_loop();
+    }
+}


### PR DESCRIPTION
- Implement interrupt framework for e907 core series, including CLIC and type-level interrupt management.
- Add non-blocking UART support using interrupts, enabling asynchronous communication.

Example `pbp-async-uart` is verified on Hengshan Pi v1.2

<img width="921" height="673" alt="image" src="https://github.com/user-attachments/assets/6f0ea37e-906f-49ff-8dab-66ce0257811c" />
