### PR TITLE
feat(all): add logging, timeout error handling, and BOOT-pin upgrade support

### DIFF
--- a/.github/workflows/Cargo.yml
+++ b/.github/workflows/Cargo.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Install cargo-tarpaulin
         run: cargo install cargo-tarpaulin
       - name: Generate code coverage
-        run: cargo tarpaulin --engine llvm -p artinchip-hal --features "d13x clic_interrupts" --out Html --output-dir ./coverage-report
+        run: cargo tarpaulin --engine llvm -p artinchip-hal --features "d13x clic-interrupts" --out Html --output-dir ./coverage-report
       - name: Upload coverage report
         uses: actions/upload-artifact@v4
         with:
@@ -75,7 +75,7 @@ jobs:
         # Bind each package to its specific interrupt feature
         PACKAGE: 
           - name: artinchip-hal
-            int_feat: clic_interrupts
+            int_feat: clic-interrupts
           - name: artinchip-rt
             int_feat: interrupts
         CHIP_FEATURE: [d12x, d13x, d21x, g73x, m6800]

--- a/artinchip-hal/Cargo.toml
+++ b/artinchip-hal/Cargo.toml
@@ -19,8 +19,11 @@ critical-section = "1.2.0"
 embassy-sync = "0.8.0"
 paste = "1.0"
 xuantie-riscv = {git = "https://github.com/rustsbi/xuantie.git", branch = "main"}
+log = { version = "0.4", default-features = false }
+heapless = { version = "0.9.3", optional = true }
 
 [features]
+uart-logger = ["dep:heapless"]
 clic-interrupts = []
 d12x = []
 d13x = []

--- a/artinchip-hal/Cargo.toml
+++ b/artinchip-hal/Cargo.toml
@@ -21,7 +21,7 @@ paste = "1.0"
 xuantie-riscv = {git = "https://github.com/rustsbi/xuantie.git", branch = "main"}
 
 [features]
-clic_interrupts = []
+clic-interrupts = []
 d12x = []
 d13x = []
 d21x = []

--- a/artinchip-hal/src/i2c.rs
+++ b/artinchip-hal/src/i2c.rs
@@ -2,6 +2,7 @@
 
 mod blocking;
 mod config;
+mod error;
 mod i2c_ext;
 mod instance;
 mod pad;
@@ -9,6 +10,7 @@ mod register;
 
 pub use blocking::*;
 pub use config::*;
+pub use error::*;
 pub use i2c_ext::I2cExt;
 pub use instance::I2c;
 pub use pad::*;

--- a/artinchip-hal/src/i2c/blocking.rs
+++ b/artinchip-hal/src/i2c/blocking.rs
@@ -3,6 +3,7 @@
 use embedded_hal::i2c::{Operation, SevenBitAddress, TenBitAddress};
 
 use super::config::{I2cConfig, Role};
+use super::error::I2cError;
 use super::instance::I2c;
 use super::pad::I2cPads;
 use super::register::{AddressMode, RegisterBlock, SpeedMode, TransferMode};
@@ -168,7 +169,7 @@ impl<'a, const I: u8, PAD> embedded_hal::i2c::ErrorType for BlockingI2c<'a, I, P
 where
     PAD: I2cPads<I>,
 {
-    type Error = core::convert::Infallible;
+    type Error = I2cError;
 }
 
 impl<'a, const I: u8, PAD> embedded_hal::i2c::I2c<SevenBitAddress> for BlockingI2c<'a, I, PAD>
@@ -230,7 +231,12 @@ where
 
                     // Read data from RX FIFO
                     for byte in buffer.iter_mut() {
+                        let mut timeout = 100_000;
                         while self.reg.rx_flr.read().rx_fifo_count() == 0 {
+                            timeout -= 1;
+                            if timeout == 0 {
+                                return Err(I2cError::Timeout);
+                            }
                             core::hint::spin_loop();
                         }
                         *byte = self.reg.data_cmd.read().data_byte();
@@ -302,7 +308,12 @@ where
 
                     // Read data from RX FIFO
                     for byte in buffer.iter_mut() {
+                        let mut timeout = 100_000;
                         while self.reg.rx_flr.read().rx_fifo_count() == 0 {
+                            timeout -= 1;
+                            if timeout == 0 {
+                                return Err(I2cError::Timeout);
+                            }
                             core::hint::spin_loop();
                         }
                         *byte = self.reg.data_cmd.read().data_byte();

--- a/artinchip-hal/src/i2c/error.rs
+++ b/artinchip-hal/src/i2c/error.rs
@@ -1,0 +1,14 @@
+//! I2C error types.
+
+/// I2C bus error.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum I2cError {
+    /// Timeout waiting for hardware.
+    Timeout,
+}
+
+impl embedded_hal::i2c::Error for I2cError {
+    fn kind(&self) -> embedded_hal::i2c::ErrorKind {
+        embedded_hal::i2c::ErrorKind::Other
+    }
+}

--- a/artinchip-hal/src/interrupt/clic.rs
+++ b/artinchip-hal/src/interrupt/clic.rs
@@ -141,6 +141,8 @@ macro_rules! clic_interrupt_mod {
 macro_rules! clic_bind_interrupts {
     ($vis:vis struct $name:ident { $($irq:ident => $handler:ty;)* }) => {
         paste::paste! {
+            use log::error;
+
             // Generate hardware vector entry for each bound interrupt
             $(
                 #[unsafe(no_mangle)]
@@ -156,15 +158,16 @@ macro_rules! clic_bind_interrupts {
             // Default handler (for unbound interrupts)
             #[unsafe(no_mangle)]
             pub extern "riscv-interrupt-m" fn __irq_handler_default() {
+                error!("Default interrupt handler called in CLIC vector table");
                 loop { core::hint::spin_loop(); }
             }
 
             // Global vector table, 64‑byte aligned (required by E907 CLIC mtvt hardware)
             #[repr(C, align(64))]
-            struct ClicVectorTable([u32; 128]);
+            struct ClicVectorTable([u32; 100]);
 
             #[unsafe(link_section = ".clic.vector_table")]
-            static mut VECTOR_TABLE: ClicVectorTable = ClicVectorTable([0; 128]);
+            static mut VECTOR_TABLE: ClicVectorTable = ClicVectorTable([0; 100]);
 
             #[derive(Copy, Clone)]
             $vis struct $name;

--- a/artinchip-hal/src/lib.rs
+++ b/artinchip-hal/src/lib.rs
@@ -10,7 +10,7 @@ pub mod dma;
 pub mod gpio;
 pub mod gtc;
 pub mod i2c;
-#[cfg(feature = "clic_interrupts")]
+#[cfg(feature = "clic-interrupts")]
 pub mod interrupt;
 pub mod pad;
 pub mod pwm;

--- a/artinchip-hal/src/qspi.rs
+++ b/artinchip-hal/src/qspi.rs
@@ -2,6 +2,7 @@
 
 mod blocking;
 mod config;
+mod error;
 mod instance;
 mod pad;
 mod qspi_ext;
@@ -9,6 +10,7 @@ mod register;
 
 pub use blocking::*;
 pub use config::*;
+pub use error::*;
 pub use instance::Qspi;
 pub use pad::*;
 pub use qspi_ext::QspiExt;

--- a/artinchip-hal/src/qspi/blocking.rs
+++ b/artinchip-hal/src/qspi/blocking.rs
@@ -5,6 +5,7 @@
 // - https://aicdoc.artinchip.com/topics/ic/qspi/qspi-programming-guide-d13x.html
 
 use super::config::*;
+use super::error::QspiError;
 use super::instance::Qspi;
 use super::pad::*;
 use super::register::*;
@@ -245,19 +246,29 @@ where
     }
 
     /// Wait for the transfer to complete.
-    fn wait_transfer_done(&mut self) {
+    fn wait_transfer_done(&mut self) -> Result<(), QspiError> {
+        let mut timeout = 100_000;
         while self.reg.trans_config.read().start() {
+            timeout -= 1;
+            if timeout == 0 {
+                return Err(QspiError::Timeout);
+            }
             core::hint::spin_loop();
         }
+        Ok(())
     }
 
     /// Write bytes to the TX FIFO.
-    fn write_bytes(&mut self, buf: &[u8]) {
+    fn write_bytes(&mut self, buf: &[u8]) -> Result<(), QspiError> {
         let mut idx = 0usize;
 
         while idx < buf.len() {
-            // Wait for FIFO to have enough space (at least one u32).
+            let mut timeout = 100_000;
             while self.reg.fifo_status.read().tx_fifo_count() >= Self::FIFO_DEPTH - 4 {
+                timeout -= 1;
+                if timeout == 0 {
+                    return Err(QspiError::Timeout);
+                }
                 core::hint::spin_loop();
             }
 
@@ -274,12 +285,13 @@ where
 
             idx += chunk;
         }
+        Ok(())
     }
 
     /// Read bytes from the RX FIFO.
-    fn read_bytes(&self, buf: &mut [u8]) {
+    fn read_bytes(&self, buf: &mut [u8]) -> Result<(), QspiError> {
         if buf.is_empty() {
-            return;
+            return Ok(());
         }
 
         let mut idx = 0usize;
@@ -288,8 +300,12 @@ where
             // Calculate the number of bytes to read this time (maximum 4 bytes).
             let chunk = core::cmp::min(4, buf.len() - idx);
 
-            // Wait for at least chunk bytes in FIFO.
+            let mut timeout = 100_000;
             while (self.reg.fifo_status.read().rx_fifo_count() as usize) < chunk {
+                timeout -= 1;
+                if timeout == 0 {
+                    return Err(QspiError::Timeout);
+                }
                 core::hint::spin_loop();
             }
 
@@ -301,6 +317,7 @@ where
 
             idx += chunk;
         }
+        Ok(())
     }
 
     /// Calculate the best internal clock divider to achieve target frequency.
@@ -399,7 +416,7 @@ impl<'a, const I: u8, PAD> embedded_hal::spi::ErrorType for BlockingQspi<'a, I, 
 where
     PAD: QspiPads<I>,
 {
-    type Error = core::convert::Infallible;
+    type Error = QspiError;
 }
 
 impl<'a, const I: u8, PAD> embedded_hal::spi::SpiBus for BlockingQspi<'a, I, PAD>
@@ -412,9 +429,8 @@ where
         }
         self.reset_fifos();
         self.start_transfer(words.len(), 0);
-        self.read_bytes(words);
-        self.wait_transfer_done();
-        Ok(())
+        self.read_bytes(words)?;
+        self.wait_transfer_done()
     }
 
     fn write(&mut self, words: &[u8]) -> Result<(), Self::Error> {
@@ -423,12 +439,16 @@ where
         }
         self.reset_fifos();
         self.start_transfer(words.len(), words.len());
-        self.write_bytes(words);
+        self.write_bytes(words)?;
+        let mut timeout = 100_000;
         while self.reg.fifo_status.read().tx_fifo_count() != 0 {
+            timeout -= 1;
+            if timeout == 0 {
+                return Err(QspiError::Timeout);
+            }
             core::hint::spin_loop();
         }
-        self.wait_transfer_done();
-        Ok(())
+        self.wait_transfer_done()
     }
 
     fn transfer(&mut self, read: &mut [u8], write: &[u8]) -> Result<(), Self::Error> {
@@ -452,8 +472,7 @@ where
     }
 
     fn flush(&mut self) -> Result<(), Self::Error> {
-        self.wait_transfer_done();
-        Ok(())
+        self.wait_transfer_done()
     }
 }
 
@@ -470,13 +489,17 @@ where
                     }
                     self.reset_fifos();
                     self.start_transfer(buf.len(), buf.len());
-                    self.write_bytes(buf);
+                    self.write_bytes(buf)?;
 
-                    // Wait for TX FIFO to empty.
+                    let mut timeout = 100_000;
                     while self.reg.fifo_status.read().tx_fifo_count() != 0 {
+                        timeout -= 1;
+                        if timeout == 0 {
+                            return Err(QspiError::Timeout);
+                        }
                         core::hint::spin_loop();
                     }
-                    self.wait_transfer_done();
+                    self.wait_transfer_done()?;
                 }
                 Operation::Read(buf) => {
                     if buf.is_empty() {
@@ -498,10 +521,14 @@ where
                     // Send dummy bytes (0xFF) to generate SCK clock.
                     let mut idx = 0;
                     while idx < buf.len() {
-                        // Wait for FIFO to have space.
+                        let mut timeout = 100_000;
                         while self.reg.fifo_status.read().tx_fifo_count()
                             >= Self::DEFAULT_TX_WATERMARK
                         {
+                            timeout -= 1;
+                            if timeout == 0 {
+                                return Err(QspiError::Timeout);
+                            }
                             core::hint::spin_loop();
                         }
 
@@ -512,15 +539,18 @@ where
                         idx += chunk;
                     }
 
-                    // Wait for dummy data to finish sending.
+                    let mut timeout = 100_000;
                     while self.reg.fifo_status.read().tx_fifo_count() != 0 {
+                        timeout -= 1;
+                        if timeout == 0 {
+                            return Err(QspiError::Timeout);
+                        }
                         core::hint::spin_loop();
                     }
 
-                    // Read data from RX FIFO.
-                    self.read_bytes(buf);
+                    self.read_bytes(buf)?;
 
-                    self.wait_transfer_done();
+                    self.wait_transfer_done()?;
 
                     // Restore settings.
                     unsafe {

--- a/artinchip-hal/src/qspi/error.rs
+++ b/artinchip-hal/src/qspi/error.rs
@@ -1,0 +1,14 @@
+//! QSPI error types.
+
+/// QSPI bus error.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QspiError {
+    /// Timeout waiting for hardware.
+    Timeout,
+}
+
+impl embedded_hal::spi::Error for QspiError {
+    fn kind(&self) -> embedded_hal::spi::ErrorKind {
+        embedded_hal::spi::ErrorKind::Other
+    }
+}

--- a/artinchip-hal/src/uart.rs
+++ b/artinchip-hal/src/uart.rs
@@ -3,7 +3,7 @@
 mod blocking;
 mod config;
 mod instance;
-#[cfg(feature = "clic_interrupts")]
+#[cfg(feature = "clic-interrupts")]
 mod non_blocking;
 mod pad;
 mod register;
@@ -11,7 +11,7 @@ mod uart_ext;
 
 pub use config::*;
 pub use instance::Uart;
-#[cfg(feature = "clic_interrupts")]
+#[cfg(feature = "clic-interrupts")]
 pub use non_blocking::*;
 pub use pad::*;
 pub use register::*;

--- a/artinchip-hal/src/uart.rs
+++ b/artinchip-hal/src/uart.rs
@@ -3,14 +3,19 @@
 mod blocking;
 mod config;
 mod instance;
+#[cfg(feature = "uart-logger")]
+mod logger;
 #[cfg(feature = "clic-interrupts")]
 mod non_blocking;
 mod pad;
 mod register;
 mod uart_ext;
 
+pub use blocking::*;
 pub use config::*;
 pub use instance::Uart;
+#[cfg(feature = "uart-logger")]
+pub use logger::*;
 #[cfg(feature = "clic-interrupts")]
 pub use non_blocking::*;
 pub use pad::*;

--- a/artinchip-hal/src/uart.rs
+++ b/artinchip-hal/src/uart.rs
@@ -2,6 +2,7 @@
 
 mod blocking;
 mod config;
+mod error;
 mod instance;
 #[cfg(feature = "uart-logger")]
 mod logger;
@@ -13,6 +14,7 @@ mod uart_ext;
 
 pub use blocking::*;
 pub use config::*;
+pub use error::*;
 pub use instance::Uart;
 #[cfg(feature = "uart-logger")]
 pub use logger::*;

--- a/artinchip-hal/src/uart/blocking.rs
+++ b/artinchip-hal/src/uart/blocking.rs
@@ -1,6 +1,7 @@
 //! Blocking serial communication interface.
 
 use super::config::{StopBits, UartConfig};
+use super::error::UartError;
 use super::instance::Uart;
 use super::pad::{Receive, Transmit, UartPad};
 use super::register::RegisterBlock;
@@ -103,12 +104,16 @@ where
     }
 
     /// Blocking write buffer.
-    pub fn blocking_write(&mut self, buf: &[u8]) -> Result<usize, ()> {
+    pub fn blocking_write(&mut self, buf: &[u8]) -> Result<usize, UartError> {
         let uart16550 = &self.reg.uart16550;
 
         for &b in buf {
-            // Wait until the transmitter FIFO is not full
+            let mut timeout = 100_000;
             while !uart16550.lsr().read().is_transmitter_fifo_empty() {
+                timeout -= 1;
+                if timeout == 0 {
+                    return Err(UartError::Timeout);
+                }
                 core::hint::spin_loop();
             }
             uart16550.rbr_thr().tx_data(b);
@@ -117,7 +122,7 @@ where
     }
 
     /// Blocking read buffer.
-    pub fn blocking_read(&mut self, buf: &mut [u8]) -> Result<usize, ()> {
+    pub fn blocking_read(&mut self, buf: &mut [u8]) -> Result<usize, UartError> {
         // TODO: implement reading into buffer
         buf.fill(0);
         Ok(0)
@@ -175,12 +180,16 @@ where
     TX: UartPad<I> + Transmit<I>,
 {
     /// Blocking write buffer.
-    pub fn blocking_write(&mut self, buf: &[u8]) -> Result<usize, ()> {
+    pub fn blocking_write(&mut self, buf: &[u8]) -> Result<usize, UartError> {
         let uart16550 = &self.reg.uart16550;
 
         for &b in buf {
-            // Wait until the transmitter FIFO is not full
+            let mut timeout = 100_000;
             while !uart16550.lsr().read().is_transmitter_fifo_empty() {
+                timeout -= 1;
+                if timeout == 0 {
+                    return Err(UartError::Timeout);
+                }
                 core::hint::spin_loop();
             }
             uart16550.rbr_thr().tx_data(b);
@@ -203,7 +212,7 @@ where
     RX: UartPad<I> + Receive<I>,
 {
     /// Blocking read buffer.
-    pub fn blocking_read(&mut self, buf: &mut [u8]) -> Result<usize, ()> {
+    pub fn blocking_read(&mut self, buf: &mut [u8]) -> Result<usize, UartError> {
         // TODO: implement reading into buffer
         buf.fill(0);
         Ok(0)
@@ -215,21 +224,21 @@ where
     TX: UartPad<I> + Transmit<I>,
     RX: UartPad<I> + Receive<I>,
 {
-    type Error = core::convert::Infallible;
+    type Error = UartError;
 }
 
 impl<'a, const I: u8, TX> embedded_io::ErrorType for TransmitHalf<'a, I, TX>
 where
     TX: UartPad<I> + Transmit<I>,
 {
-    type Error = core::convert::Infallible;
+    type Error = UartError;
 }
 
 impl<'a, const I: u8, RX> embedded_io::ErrorType for ReceiveHalf<'a, I, RX>
 where
     RX: UartPad<I> + Receive<I>,
 {
-    type Error = core::convert::Infallible;
+    type Error = UartError;
 }
 
 impl<'a, const I: u8, TX, RX> embedded_io::Write for BlockingSerial<'a, I, TX, RX>
@@ -239,12 +248,16 @@ where
 {
     #[inline]
     fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
-        self.blocking_write(buf).ok();
-        Ok(buf.len())
+        self.blocking_write(buf)
     }
     #[inline]
     fn flush(&mut self) -> Result<(), Self::Error> {
+        let mut timeout = 100_000;
         while !self.reg.usr.read().is_transmit_fifo_empty() {
+            timeout -= 1;
+            if timeout == 0 {
+                return Err(UartError::Timeout);
+            }
             core::hint::spin_loop();
         }
         Ok(())
@@ -257,12 +270,16 @@ where
 {
     #[inline]
     fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
-        self.blocking_write(buf).ok();
-        Ok(buf.len())
+        self.blocking_write(buf)
     }
     #[inline]
     fn flush(&mut self) -> Result<(), Self::Error> {
+        let mut timeout = 100_000;
         while !self.reg.usr.read().is_transmit_fifo_empty() {
+            timeout -= 1;
+            if timeout == 0 {
+                return Err(UartError::Timeout);
+            }
             core::hint::spin_loop();
         }
         Ok(())
@@ -276,8 +293,7 @@ where
 {
     #[inline]
     fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
-        self.blocking_read(buf).ok();
-        Ok(buf.len())
+        self.blocking_read(buf)
     }
 }
 
@@ -287,7 +303,6 @@ where
 {
     #[inline]
     fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
-        self.blocking_read(buf).ok();
-        Ok(buf.len())
+        self.blocking_read(buf)
     }
 }

--- a/artinchip-hal/src/uart/error.rs
+++ b/artinchip-hal/src/uart/error.rs
@@ -1,0 +1,26 @@
+//! UART error types.
+
+use core::fmt;
+
+/// UART bus error.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UartError {
+    /// Timeout waiting for hardware.
+    Timeout,
+}
+
+impl fmt::Display for UartError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Timeout => write!(f, "UART timeout"),
+        }
+    }
+}
+
+impl core::error::Error for UartError {}
+
+impl embedded_io::Error for UartError {
+    fn kind(&self) -> embedded_io::ErrorKind {
+        embedded_io::ErrorKind::Other
+    }
+}

--- a/artinchip-hal/src/uart/instance.rs
+++ b/artinchip-hal/src/uart/instance.rs
@@ -7,17 +7,17 @@ use super::register::RegisterBlock;
 use super::uart_ext::UartExt;
 use crate::cmu::Cmu;
 use core::marker::PhantomData;
-#[cfg(feature = "clic_interrupts")]
+#[cfg(feature = "clic-interrupts")]
 use {super::non_blocking::*, crate::interrupt::clic::typelevel};
 
 /// Trait to map const generic I to its interrupt type (used for compile-time safety).
-#[cfg(feature = "clic_interrupts")]
+#[cfg(feature = "clic-interrupts")]
 pub trait UartInterrupt<const I: u8> {
     type Interrupt: typelevel::Interrupt;
 }
 
 // Macro to quickly map instance numbers to interrupt types
-#[cfg(feature = "clic_interrupts")]
+#[cfg(feature = "clic-interrupts")]
 macro_rules! impl_uart_interrupts {
     ( $( ($inst:literal, $irq_type:ident) ),* $(,)? ) => {
         $(
@@ -29,14 +29,14 @@ macro_rules! impl_uart_interrupts {
 }
 
 // Macro to quickly map instance numbers to interrupt types
-#[cfg(feature = "clic_interrupts")]
+#[cfg(feature = "clic-interrupts")]
 impl_uart_interrupts! {
     (0, UART0),
     (1, UART1),
     (2, UART2),
     (3, UART3),
 }
-#[cfg(feature = "clic_interrupts")]
+#[cfg(feature = "clic-interrupts")]
 #[cfg(not(feature = "d12x"))]
 impl_uart_interrupts! {
     (4, UART4),
@@ -66,7 +66,7 @@ impl<const I: u8> Uart<I> {
     }
 
     /// Get register block for a specific index (used by Interrupt Handler).
-    #[cfg(feature = "clic_interrupts")]
+    #[cfg(feature = "clic-interrupts")]
     #[inline(always)]
     pub(crate) unsafe fn regs_at_index() -> &'static RegisterBlock {
         let base_addr = 0x18710000 + (I as usize) * 0x1000;
@@ -90,7 +90,7 @@ impl<const I: u8> UartExt<'static, I> for Uart<I> {
     {
         BlockingSerial::new(self.register_block(), tx, rx, config, cmu)
     }
-    #[cfg(feature = "clic_interrupts")]
+    #[cfg(feature = "clic-interrupts")]
     #[inline]
     fn new_async<TX, RX, IRQS>(
         self,

--- a/artinchip-hal/src/uart/logger.rs
+++ b/artinchip-hal/src/uart/logger.rs
@@ -1,0 +1,91 @@
+//! UART0 logger driven by BlockingSerial — polling TX works even with interrupts disabled.
+
+use core::fmt::Write as _;
+
+use crate::{cmu::Cmu, uart::*};
+use heapless::String;
+use log::{LevelFilter, Log, Metadata, Record, SetLoggerError};
+
+static mut REG: *const RegisterBlock = core::ptr::null();
+static mut INITIALIZED: bool = false;
+
+struct Uart0Logger;
+
+impl Log for Uart0Logger {
+    fn enabled(&self, _metadata: &Metadata) -> bool {
+        unsafe { INITIALIZED }
+    }
+
+    fn log(&self, record: &Record) {
+        unsafe {
+            if !INITIALIZED {
+                return;
+            }
+        }
+
+        let reg = unsafe { &*REG };
+        let uart16550 = &reg.uart16550;
+
+        let mut s: String<256> = String::new();
+        write!(s, "[{}] {}", record.level(), record.args()).ok();
+
+        for &byte in s.as_bytes() {
+            while !uart16550.lsr().read().is_transmitter_fifo_empty() {
+                core::hint::spin_loop();
+            }
+            uart16550.rbr_thr().tx_data(byte);
+        }
+        // Newline after each record
+        while !uart16550.lsr().read().is_transmitter_fifo_empty() {
+            core::hint::spin_loop();
+        }
+        uart16550.rbr_thr().tx_data(b'\n');
+
+        self.flush();
+    }
+
+    fn flush(&self) {
+        unsafe {
+            if !INITIALIZED {
+                return;
+            }
+        }
+        let reg = unsafe { &*REG };
+        while !reg.uart16550.lsr().read().is_transmitter_empty() {
+            core::hint::spin_loop();
+        }
+    }
+}
+
+/// Initialize the global logger on UART0 and return a `BlockingSerial`.
+///
+/// The returned `BlockingSerial` can be used for subsequent blocking I/O
+/// independently of the logger (theoretically it won't conflict with logging,
+/// but using UART0 for general data transfer is not recommended).
+pub fn uart_logger_init<TX, RX>(
+    uart: Uart<0>,
+    tx: TX,
+    rx: RX,
+    config: UartConfig,
+    cmu: &mut Cmu,
+) -> Result<BlockingSerial<'static, 0, TX, RX>, SetLoggerError>
+where
+    TX: UartPad<0> + Transmit<0>,
+    RX: UartPad<0> + Receive<0>,
+    Uart<0>: UartExt<'static, 0>,
+{
+    let reg_ptr: *const RegisterBlock = uart.register_block() as *const RegisterBlock;
+
+    // `new_blocking` handles all hardware initialization.
+    let serial = uart.new_blocking(tx, rx, config, cmu);
+
+    unsafe {
+        REG = reg_ptr;
+        INITIALIZED = true;
+    }
+
+    log::set_logger(&Uart0Logger)?;
+    log::set_max_level(LevelFilter::Trace);
+
+    Ok(serial)
+}

--- a/artinchip-hal/src/uart/uart_ext.rs
+++ b/artinchip-hal/src/uart/uart_ext.rs
@@ -5,7 +5,7 @@ use super::config::UartConfig;
 use super::pad::UartPad;
 use super::pad::{Receive, Transmit};
 use crate::cmu::Cmu;
-#[cfg(feature = "clic_interrupts")]
+#[cfg(feature = "clic-interrupts")]
 use {super::instance::*, super::non_blocking::*, crate::interrupt::clic::typelevel};
 
 pub trait UartExt<'a, const I: u8> {
@@ -21,7 +21,7 @@ pub trait UartExt<'a, const I: u8> {
         TX: UartPad<I> + Transmit<I>,
         RX: UartPad<I> + Receive<I>;
     /// Creates a non-blocking UART interface with the specified pads.
-    #[cfg(feature = "clic_interrupts")]
+    #[cfg(feature = "clic-interrupts")]
     fn new_async<TX, RX, IRQS>(
         self,
         tx: TX,

--- a/artinchip-rt/Cargo.toml
+++ b/artinchip-rt/Cargo.toml
@@ -11,8 +11,10 @@ authors = [
 artinchip-rt-macros = { version = "0.0.0", path = "macros" }
 artinchip-hal = { version = "0.0.0", path = "../artinchip-hal" }
 embedded-hal = "1.0.0"
+riscv = { version = "0.16.0", features = ["critical-section-single-hart"] }
 paste = "1.0"
 xuantie-riscv = { git = "https://github.com/rustsbi/xuantie.git", branch = "main" }
+log = { version = "0.4", default-features = false }
 
 [features]
 interrupts = []

--- a/artinchip-rt/macros/src/lib.rs
+++ b/artinchip-rt/macros/src/lib.rs
@@ -10,11 +10,13 @@ use proc_macro::TokenStream;
 
 /// Pre-Boot Program (PBP) entry.
 ///
-/// In Rust, PBP entry function should follow this convention listed below:
+/// The first parameter must be `BootParam` from `artinchip_rt::core::boot_rom`:
 ///
 /// ```rust
+/// use artinchip_rt::core::boot_rom::BootParam;
+///
 /// #[pbp_entry]
-/// [unsafe] fn pbp_main(boot_param: u32, private_data: &[u8])
+/// fn pbp_main(boot_param: BootParam, private_data: &[u8])
 /// ```
 #[proc_macro_attribute]
 pub fn pbp_entry(args: TokenStream, input: TokenStream) -> TokenStream {
@@ -94,7 +96,7 @@ pub fn pbp_entry(args: TokenStream, input: TokenStream) -> TokenStream {
     if !valid_signature {
         return parse::Error::new(
             f.span(),
-            "`#[pbp_entry]` function must have signature `[unsafe] fn pbp_main(boot_param: u32, private_data: &[u8])`",
+            "`#[pbp_entry]` function must have signature `[unsafe] fn pbp_main(boot_param: BootParam, private_data: &[u8])`",
         )
         .to_compile_error()
         .into();
@@ -118,6 +120,7 @@ pub fn pbp_entry(args: TokenStream, input: TokenStream) -> TokenStream {
         #(#attrs)*
         pub extern "C" fn #ident(boot_param: u32, priv_addr: *const u8, priv_len: u32) #ret {
             let private_data = unsafe { core::slice::from_raw_parts(priv_addr, priv_len as usize) };
+            let boot_param = ::artinchip_rt::core::boot_rom::BootParam::from_raw(boot_param);
             unsafe { __artinchip_rt__pbp_main(boot_param, private_data ) }
         }
         #[allow(non_snake_case)]

--- a/artinchip-rt/src/core.rs
+++ b/artinchip-rt/src/core.rs
@@ -1,2 +1,3 @@
+pub mod boot_rom;
 pub mod cache;
 pub mod trap;

--- a/artinchip-rt/src/core/boot_rom.rs
+++ b/artinchip-rt/src/core/boot_rom.rs
@@ -1,6 +1,7 @@
 //! ArtInChip Boot ROM API.
 
 use super::cache::{_disable_cache, dcache_clean_invalidate_range};
+use log::info;
 
 /// Boot reason (bits [11:8] of boot_param).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -106,6 +107,15 @@ impl BootParam {
     pub const fn as_raw(self) -> u32 {
         self.0
     }
+}
+
+/// Print boot information.
+pub fn print_boot_info(boot_param: &BootParam) {
+    info!("Boot param: 0x{:08X}", boot_param.as_raw());
+    info!("Boot device: {:?}", boot_param.boot_device());
+    info!("Boot controller: {:?}", boot_param.boot_controller());
+    info!("Boot reason: {:?}", boot_param.boot_reason());
+    info!("Boot image ID: {}", boot_param.boot_image_id());
 }
 
 /// Check startup.

--- a/artinchip-rt/src/core/boot_rom.rs
+++ b/artinchip-rt/src/core/boot_rom.rs
@@ -1,0 +1,210 @@
+//! ArtInChip Boot ROM API.
+
+use super::cache::{_disable_cache, dcache_clean_invalidate_range};
+
+/// Boot reason (bits [11:8] of boot_param).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum BootReason {
+    ColdBoot,
+    WarmBoot,
+}
+
+/// Boot device (bits [3:0] of boot_param).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum BootDevice {
+    None,
+    Sdmc0,
+    Sdmc1,
+    Sdmc2,
+    Spinor,
+    Spinand,
+    Sdfat32,
+    Usb,
+    Udisk,
+}
+
+/// Boot controller (bits [7:4] of boot_param).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum BootController {
+    None,
+    Sdmc0,
+    Sdmc1,
+    Sdmc2,
+    Spi0,
+    Spi1,
+    Usb,
+}
+
+/// Boot parameter passed from BROM via a0 register.
+///
+/// Bit layout:
+/// - bits [3:0]   → boot_device
+/// - bits [7:4]   → boot_controller
+/// - bits [11:8]  → boot_reason
+/// - bits [15:12] → boot_image_id
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(transparent)]
+pub struct BootParam(u32);
+
+impl BootParam {
+    #[inline]
+    pub fn boot_device(self) -> BootDevice {
+        match self.0 & 0xF {
+            0 => BootDevice::None,
+            1 => BootDevice::Sdmc0,
+            2 => BootDevice::Sdmc1,
+            3 => BootDevice::Sdmc2,
+            4 => BootDevice::Spinor,
+            5 => BootDevice::Spinand,
+            6 => BootDevice::Sdfat32,
+            7 => BootDevice::Usb,
+            8 => BootDevice::Udisk,
+            _ => BootDevice::None,
+        }
+    }
+
+    #[inline]
+    pub fn boot_controller(self) -> BootController {
+        match (self.0 >> 4) & 0xF {
+            0 => BootController::None,
+            1 => BootController::Sdmc0,
+            2 => BootController::Sdmc1,
+            3 => BootController::Sdmc2,
+            4 => BootController::Spi0,
+            5 => BootController::Spi1,
+            6 => BootController::Usb,
+            _ => BootController::None,
+        }
+    }
+
+    #[inline]
+    pub fn boot_reason(self) -> BootReason {
+        match (self.0 >> 8) & 0xF {
+            0 => BootReason::ColdBoot,
+            _ => BootReason::WarmBoot,
+        }
+    }
+
+    #[inline]
+    pub fn boot_image_id(self) -> u8 {
+        ((self.0 >> 12) & 0xF) as u8
+    }
+}
+
+impl BootParam {
+    /// Construct from raw `u32` value received via BROM's a0 register.
+    #[inline]
+    pub const fn from_raw(v: u32) -> Self {
+        BootParam(v)
+    }
+
+    /// Get the underlying raw `u32` value.
+    #[inline]
+    pub const fn as_raw(self) -> u32 {
+        self.0
+    }
+}
+
+/// Check startup.
+pub fn check_startup(boot_param: &BootParam) {
+    #[cfg(any(
+        feature = "d12x",
+        feature = "d13x",
+        feature = "g73x",
+        feature = "m6800"
+    ))]
+    {
+        check_e907_upg_req(boot_param);
+    }
+    #[cfg(feature = "d21x")]
+    {
+        // Just read boot reason to avoid unused variable warning
+        let _ = boot_param.boot_reason();
+    }
+}
+
+/// Jump to BROM USB upgrade mode entry for E907 series.
+///
+/// # Safety
+///
+/// This function will disable caches and jump to BROM upgrade entry point unconditionally.
+pub unsafe fn jump_to_e907_upg_entry() {
+    // 1. Read BROM version magic number to select upgrade entry
+    let brom_ver: u8 = unsafe { core::ptr::read_volatile(0x3000_0066 as *const u8) };
+    let entry: u32 = match brom_ver {
+        0x33 => 0x3000_7BE6,
+        0x37 => 0x3000_7DD0,
+        _ => {
+            // Unknown BROM version, fall into dead loop
+            loop {
+                core::hint::spin_loop();
+            }
+        }
+    };
+
+    // 2. dcache clean + invalidate all
+    unsafe { dcache_clean_invalidate_range(0x3000_0000, 0x10000) };
+
+    // 3. Disable D-Cache and I-Cache
+    unsafe {
+        _disable_cache();
+
+        // 4. Switch to BROM stack space and jump to upgrade entry
+        core::arch::asm!(
+            "li sp, 0x30044000",
+            "jr a0",
+            in("a0") entry,
+            options(noreturn, nomem, nostack),
+        );
+    }
+}
+
+/// Check if E907 upgrade mode is requested by user.
+///
+/// If BOOT button (PA0, active-low) is held down on cold boot,
+/// this function will jump to BROM upgrade entry point unconditionally.
+pub fn check_e907_upg_req(boot_param: &BootParam) {
+    // PA group base: 0x18700000
+    //   +0x00: input_state (GEN_IN_STA)
+    //   +0x80: pin_config[0]  (PIN_CFG)
+    const PA_INPUT_STA: u32 = 0x1870_0000;
+    const PA0_PIN_CFG: u32 = 0x1870_0080;
+
+    // Only check BOOT button on cold boot
+    if boot_param.boot_reason() != BootReason::ColdBoot {
+        return;
+    }
+
+    // Configure PA0: PIN_FUN=1 (GPIO), GEN_IE=1 (input enable), PIN_PULL=PullUp
+    // PinConfig layout: bit16=GEN_IE, bit9:8=PIN_PULL(3=PullUp), bit3:0=PIN_FUN(1)
+    unsafe {
+        core::ptr::write_volatile(PA0_PIN_CFG as *mut u32, 0x0001_0301);
+    }
+
+    // Wait for button state to stabilize
+    for _ in 0..100_000 {
+        core::hint::spin_loop();
+    }
+
+    // Debounced read: PA0 is active-low (pressed = input_state bit0 == 0)
+    let state_0 = unsafe {
+        let in_sta = core::ptr::read_volatile(PA_INPUT_STA as *const u32);
+        in_sta & 1 == 0
+    };
+
+    for _ in 0..100_000 {
+        core::hint::spin_loop();
+    }
+
+    let state_1 = unsafe {
+        let in_sta = core::ptr::read_volatile(PA_INPUT_STA as *const u32);
+        in_sta & 1 == 0
+    };
+
+    if state_0 && state_1 {
+        unsafe { jump_to_e907_upg_entry() };
+    }
+}

--- a/artinchip-rt/src/core/cache.rs
+++ b/artinchip-rt/src/core/cache.rs
@@ -19,6 +19,18 @@ pub(crate) extern "C" fn _enable_cache() {
     }
 }
 
+/// Disable I-Cache and D-Cache.
+///
+/// # Safety
+/// Caller must ensure that no code will be executed from I-cache after this call.
+#[unsafe(no_mangle)]
+pub(crate) extern "C" fn _disable_cache() {
+    unsafe {
+        mhcr::clear_ie();
+        mhcr::clear_de();
+    }
+}
+
 #[cfg(any(
     feature = "d12x",
     feature = "d13x",

--- a/artinchip-rt/src/core/cache.rs
+++ b/artinchip-rt/src/core/cache.rs
@@ -1,6 +1,7 @@
 //! ArtInChip cache management.
 
 use core::sync::atomic::{Ordering, fence};
+use log::error;
 use xuantie_riscv::asm::{dcache_cipa, dcache_ipa};
 use xuantie_riscv::register::mhcr;
 
@@ -50,6 +51,7 @@ pub const CACHE_LINE: usize = 64;
 #[inline]
 pub unsafe fn dcache_clean_invalidate_range(addr: usize, len: usize) {
     if len == 0 {
+        error!("dcache_clean_invalidate_range called with len=0");
         return;
     }
 
@@ -74,6 +76,7 @@ pub unsafe fn dcache_clean_invalidate_range(addr: usize, len: usize) {
 #[inline]
 pub unsafe fn dcache_invalidate_range(addr: usize, len: usize) {
     if len == 0 {
+        error!("dcache_invalidate_range called with len=0");
         return;
     }
 

--- a/artinchip-rt/src/core/trap.rs
+++ b/artinchip-rt/src/core/trap.rs
@@ -1,6 +1,8 @@
 //! ArtInChip RT Trap Handler.
 
 use core::arch::global_asm;
+use log::error;
+use riscv::register::*;
 
 // 64-byte aligned trampoline for hardware vectoring requirement
 global_asm!(
@@ -21,6 +23,51 @@ global_asm!(
 /// restore the context (registers) before and after execution.
 #[unsafe(no_mangle)]
 pub unsafe extern "riscv-interrupt-m" fn DefaultTrapHandler() {
+    let mcause = mcause::read();
+    let mepc = mepc::read();
+    let mtval = mtval::read();
+    let mstatus = mstatus::read();
+    let mtvec = mtvec::read();
+    let mip = mip::read();
+    let mhcr: usize;
+    let mhint: usize;
+    unsafe {
+        core::arch::asm!("csrr {}, 0x7C1", out(reg) mhcr);
+        core::arch::asm!("csrr {}, 0x7C5", out(reg) mhint);
+    };
+
+    let kind = if mcause.is_interrupt() {
+        "Interrupt"
+    } else {
+        "Exception"
+    };
+
+    error!(
+        "TRAP: {} (MCAUSE={}, MEPC={:#010X}, MTVAL={:#010X})",
+        kind,
+        mcause.code(),
+        mepc,
+        mtval
+    );
+    error!("MSTATUS={:#010X}", mstatus.bits());
+    error!("MTVEC={:#010X}", mtvec.bits());
+    error!("MIP={:#010X}", mip.bits());
+    error!("MHCR={:#010X}", mhcr);
+    error!("MHINT={:#010X}", mhint);
+    #[cfg(any(
+        feature = "d12x",
+        feature = "d13x",
+        feature = "g73x",
+        feature = "m6800"
+    ))]
+    {
+        let mexstatus: usize;
+        unsafe {
+            core::arch::asm!("csrr {}, 0x7E1", out(reg) mexstatus);
+        }
+        error!("MEXSTATUS={:#010X}", mexstatus);
+    }
+
     loop {
         core::hint::spin_loop();
     }
@@ -42,10 +89,25 @@ mod placeholder {
     ///
     /// # Safety
     ///
-    /// This function does nothing, only serves as a placeholder
-    /// to satisfy the linker when interrupts are disabled.
+    /// This function does nothing, only set the default trap.
     #[unsafe(no_mangle)]
     pub unsafe extern "C" fn _init_vector_table() {
-        // Do nothing if CLIC interrupts are not enabled in Cargo.toml
+        #[cfg(any(
+            feature = "d12x",
+            feature = "d13x",
+            feature = "g73x",
+            feature = "m6800"
+        ))]
+        unsafe {
+            // Set mtvec to AlignedTrapHandler in CLIC mode (MODE=3),
+            // matching the interrupts path.
+            unsafe extern "C" {
+                fn AlignedTrapHandler();
+            }
+            let trap_addr = (AlignedTrapHandler as *const () as usize & !0x3) | 3;
+            core::arch::asm!("csrw mtvec, {}", in(reg) trap_addr);
+
+            riscv::interrupt::enable();
+        }
     }
 }

--- a/artinchip-rt/src/lib.rs
+++ b/artinchip-rt/src/lib.rs
@@ -13,6 +13,7 @@ pub mod soc;
 
 /// ArtInChip RT prelude.
 pub mod prelude {
+    pub use crate::core::{boot_rom::*, cache::*};
     pub use crate::gpio::PadExt as _;
 }
 

--- a/artinchip-rt/src/pbp.rs
+++ b/artinchip-rt/src/pbp.rs
@@ -21,7 +21,7 @@ pub static PBP_HEADER: PbpHeader = PbpHeader {
 
 #[unsafe(link_section = ".bss.uninit")]
 static mut STACK: [u8; STACK_SIZE] = [0u8; STACK_SIZE];
-const STACK_SIZE: usize = 1024; // 1 KiB
+const STACK_SIZE: usize = 2048; // 2 KiB
 
 const MXSTATUS: u16 = 0x7c0;
 const MEXSTATUS: u16 = 0x7e1;

--- a/examples/pbp/pbp-async-uart/Cargo.toml
+++ b/examples/pbp/pbp-async-uart/Cargo.toml
@@ -10,12 +10,14 @@ embedded-io-async = "0.7.0"
 embassy-futures = "0.1.1"
 critical-section = "1.2.0"
 riscv = { version = "0.16.0", features = ["critical-section-single-hart"] }
-heapless = "0.8"
+heapless = "0.9.3"
 paste = "1.0"
 artinchip-hal = { version = "0.0.0", path = "../../../artinchip-hal" }
 artinchip-rt = { version = "0.0.0", path = "../../../artinchip-rt" }
+log = { version = "0.4", default-features = false }
 
 [features]
-default = ["d13x", "artinchip-rt/interrupts", "artinchip-hal/clic-interrupts"]
+default = ["d13x", "logger", "artinchip-rt/interrupts", "artinchip-hal/clic-interrupts"]
+logger = ["artinchip-hal/uart-logger"]
 d13x = ["artinchip-rt/d13x", "artinchip-hal/d13x"]
 # TODO other features for all the chips.

--- a/examples/pbp/pbp-async-uart/Cargo.toml
+++ b/examples/pbp/pbp-async-uart/Cargo.toml
@@ -16,6 +16,6 @@ artinchip-hal = { version = "0.0.0", path = "../../../artinchip-hal" }
 artinchip-rt = { version = "0.0.0", path = "../../../artinchip-rt" }
 
 [features]
-default = ["d13x", "artinchip-rt/interrupts", "artinchip-hal/clic_interrupts"]
+default = ["d13x", "artinchip-rt/interrupts", "artinchip-hal/clic-interrupts"]
 d13x = ["artinchip-rt/d13x", "artinchip-hal/d13x"]
 # TODO other features for all the chips.

--- a/examples/pbp/pbp-async-uart/src/main.rs
+++ b/examples/pbp/pbp-async-uart/src/main.rs
@@ -11,10 +11,11 @@ use embassy_futures::block_on;
 use embedded_io_async::Read as _;
 use embedded_io_async::Write as _;
 use heapless::String;
+use log::info;
 use panic_halt as _;
 
 clic_bind_interrupts!(struct Irqs {
-    UART0 => AsyncUartHandler<0>;
+    UART3 => AsyncUartHandler<3>;
 });
 
 const TEST_MSG: &str = r#"die Ruinenstadt ist immer noch schön
@@ -47,36 +48,51 @@ fn pbp_main(boot_param: BootParam, _private_data: &[u8]) {
 
     let uart0_tx = p.gpioa.pa0.into_uart0_tx();
     let uart0_rx = p.gpioa.pa1.into_uart0_rx();
-    let mut uart0_async =
-        p.uart0
-            .new_async(uart0_tx, uart0_rx, UartConfig::default(), &mut p.cmu, Irqs);
+    let uart3_tx = p.gpioa.pa6.into_uart3_tx();
+    let uart3_rx = p.gpioa.pa7.into_uart3_rx();
+    let mut uart3_async =
+        p.uart3
+            .new_async(uart3_tx, uart3_rx, UartConfig::default(), &mut p.cmu, Irqs);
+    let _uart0 = uart_logger_init(
+        p.uart0,
+        uart0_tx,
+        uart0_rx,
+        UartConfig::default(),
+        &mut p.cmu,
+    )
+    .unwrap();
+
+    info!("Async UART example started. Please check the output on UART3.");
+    info!("PA6 -> UART3_TX, PA7 -> UART3_RX");
 
     block_on(async {
         let mut buf: String<128> = String::new();
         let mut rx_buf = [0u8; 256];
 
         writeln!(buf, "Welcome to pbp async uart example by artinchip-hal🦀!").ok();
-        uart0_async.write_all(buf.as_bytes()).await.ok();
+        uart3_async.write_all(buf.as_bytes()).await.ok();
 
         buf.clear();
-        writeln!(buf, "The following is a test message sent via async UART.").ok();
-        uart0_async.write_all(buf.as_bytes()).await.ok();
+        writeln!(buf, "The following is a test message sent via async UART3.").ok();
+        uart3_async.write_all(buf.as_bytes()).await.ok();
 
-        uart0_async.write_all(TEST_MSG.as_bytes()).await.ok();
-        uart0_async.flush().await.ok();
+        uart3_async.write_all(TEST_MSG.as_bytes()).await.ok();
+        uart3_async.flush().await.ok();
 
         buf.clear();
         writeln!(buf, "\r\n\r\nPlease send a message and press Enter:").ok();
-        uart0_async.write_all(buf.as_bytes()).await.ok();
+        uart3_async.write_all(buf.as_bytes()).await.ok();
 
-        let read_len = uart0_async.read(&mut rx_buf).await.ok().unwrap_or(0);
+        let read_len = uart3_async.read(&mut rx_buf).await.ok().unwrap_or(0);
         buf.clear();
         writeln!(buf, "You sent:").ok();
-        uart0_async.write_all(buf.as_bytes()).await.ok();
-        uart0_async.write_all(&rx_buf[..read_len]).await.ok();
+        uart3_async.write_all(buf.as_bytes()).await.ok();
+        uart3_async.write_all(&rx_buf[..read_len]).await.ok();
 
-        uart0_async.flush().await.ok();
+        uart3_async.flush().await.ok();
     });
+
+    info!("Async UART example completed. Please check the output on UART3.");
 
     loop {
         core::hint::spin_loop();

--- a/examples/pbp/pbp-async-uart/src/main.rs
+++ b/examples/pbp/pbp-async-uart/src/main.rs
@@ -5,7 +5,7 @@
 use artinchip_hal::clic_bind_interrupts;
 use artinchip_hal::prelude::*;
 use artinchip_hal::uart::*;
-use artinchip_rt::{Peripherals, pbp_entry};
+use artinchip_rt::{Peripherals, pbp_entry, prelude::*};
 use core::fmt::Write as _;
 use embassy_futures::block_on;
 use embedded_io_async::Read as _;
@@ -41,7 +41,8 @@ werde ich wach und singe ein Lied
 das Vergissmeinnicht, das du mir gegeben hast, ist hier"#;
 
 #[pbp_entry]
-fn pbp_main(_boot_param: u32, _private_data: &[u8]) {
+fn pbp_main(boot_param: BootParam, _private_data: &[u8]) {
+    check_startup(&boot_param);
     let mut p = Peripherals::take();
 
     let uart0_tx = p.gpioa.pa0.into_uart0_tx();

--- a/examples/pbp/pbp-blinky/Cargo.toml
+++ b/examples/pbp/pbp-blinky/Cargo.toml
@@ -7,8 +7,10 @@ edition = "2024"
 panic-halt = "1.0.0"
 artinchip-hal = { version = "0.0.0", path = "../../../artinchip-hal" }
 artinchip-rt = { version = "0.0.0", path = "../../../artinchip-rt" }
+log = { version = "0.4", default-features = false }
 
 [features]
-default = ["d13x"]
+default = ["d13x", "logger"]
+logger = ["artinchip-hal/uart-logger"]
 d13x = ["artinchip-rt/d13x", "artinchip-hal/d13x"]
 # TODO other features for all the chips.

--- a/examples/pbp/pbp-blinky/src/main.rs
+++ b/examples/pbp/pbp-blinky/src/main.rs
@@ -8,7 +8,8 @@ use artinchip_rt::{Peripherals, pbp_entry};
 use panic_halt as _;
 
 #[pbp_entry]
-fn pbp_main(_boot_param: u32, _private_data: &[u8]) {
+fn pbp_main(boot_param: BootParam, _private_data: &[u8]) {
+    check_startup(&boot_param);
     let mut p = Peripherals::take();
     let mut delay = p.gtc.new_timer_delay(CntFreq::Freq4M, &mut p.cmu);
     let mut pa5 = p.gpioa.pa5.into_pull_up_output();

--- a/examples/pbp/pbp-blinky/src/main.rs
+++ b/examples/pbp/pbp-blinky/src/main.rs
@@ -3,8 +3,10 @@
 
 use artinchip_hal::gtc::CntFreq;
 use artinchip_hal::prelude::*;
+use artinchip_hal::uart::*;
 use artinchip_rt::prelude::*;
 use artinchip_rt::{Peripherals, pbp_entry};
+use log::info;
 use panic_halt as _;
 
 #[pbp_entry]
@@ -13,6 +15,10 @@ fn pbp_main(boot_param: BootParam, _private_data: &[u8]) {
     let mut p = Peripherals::take();
     let mut delay = p.gtc.new_timer_delay(CntFreq::Freq4M, &mut p.cmu);
     let mut pa5 = p.gpioa.pa5.into_pull_up_output();
+    let tx = p.gpioa.pa0.into_uart0_tx();
+    let rx = p.gpioa.pa1.into_uart0_rx();
+    let _uart0 = uart_logger_init(p.uart0, tx, rx, UartConfig::default(), &mut p.cmu).unwrap();
+    info!("Welcome to pbp blinky example by artinchip-hal🦀!");
 
     loop {
         pa5.toggle().ok();

--- a/examples/pbp/pbp-boot-info/Cargo.toml
+++ b/examples/pbp/pbp-boot-info/Cargo.toml
@@ -8,8 +8,10 @@ panic-halt = "1.0.0"
 embedded-io = "0.7.1"
 artinchip-hal = { version = "0.0.0", path = "../../../artinchip-hal" }
 artinchip-rt = { version = "0.0.0", path = "../../../artinchip-rt" }
+log = { version = "0.4", default-features = false }
 
 [features]
-default = ["d13x"]
+default = ["d13x", "logger"]
+logger = ["artinchip-hal/uart-logger"]
 d13x = ["artinchip-rt/d13x", "artinchip-hal/d13x"]
 # TODO other features for all the chips.

--- a/examples/pbp/pbp-boot-info/src/main.rs
+++ b/examples/pbp/pbp-boot-info/src/main.rs
@@ -6,7 +6,7 @@ use artinchip_hal::prelude::*;
 use artinchip_hal::uart::*;
 use artinchip_hal::wdog::RegWrMode;
 use artinchip_rt::{Peripherals, pbp_entry, prelude::*};
-use embedded_io::Write;
+use log::info;
 use panic_halt as _;
 
 #[pbp_entry]
@@ -16,9 +16,7 @@ fn pbp_main(boot_param: BootParam, _private_data: &[u8]) {
     let tx = p.gpioa.pa0.into_uart0_tx();
     let rx = p.gpioa.pa1.into_uart0_rx();
 
-    let mut uart0 = p
-        .uart0
-        .new_blocking(tx, rx, UartConfig::default(), &mut p.cmu);
+    let _uart0 = uart_logger_init(p.uart0, tx, rx, UartConfig::default(), &mut p.cmu).unwrap();
     let mut delay = p.gtc.new_timer_delay(CntFreq::Freq4M, &mut p.cmu);
 
     let reset_info = p.wri.new_reset_info();
@@ -30,22 +28,18 @@ fn pbp_main(boot_param: BootParam, _private_data: &[u8]) {
     wdog.set_wr_mode(RegWrMode::WriteProtect);
     wdog.op_cfg_sw(0);
 
-    writeln!(
-        uart0,
-        "Welcome to pbp boot info example by artinchip-hal🦀!"
-    )
-    .ok();
+    info!("Welcome to pbp boot info example by artinchip-hal🦀!");
 
-    writeln!(uart0, "Reset reason: {:?}", reset_info.reason(),).ok();
-    writeln!(uart0, "Watchdog active channel: {}", wdog.channel_id()).ok();
-    writeln!(uart0, "Watchdog write mode: {:?}", wdog.wr_mode()).ok();
-    writeln!(uart0, "Watchdog thresholds:").ok();
-    writeln!(uart0, "  Clear threshold: {}", wdog.thd(0).0).ok();
-    writeln!(uart0, "  IRQ threshold: {}", wdog.thd(0).1).ok();
-    writeln!(uart0, "  Reset threshold: {}", wdog.thd(0).2).ok();
+    info!("Reset reason: {:?}", reset_info.reason());
+    info!("Watchdog active channel: {}", wdog.channel_id());
+    info!("Watchdog write mode: {:?}", wdog.wr_mode());
+    info!("Watchdog thresholds:");
+    info!("  Clear threshold: {}", wdog.thd(0).0);
+    info!("  IRQ threshold: {}", wdog.thd(0).1);
+    info!("  Reset threshold: {}", wdog.thd(0).2);
 
     loop {
-        writeln!(uart0, "Current time: {} seconds", time.time()).ok();
+        info!("Current time: {} seconds", time.time());
         delay.delay_ms(2000);
     }
 }

--- a/examples/pbp/pbp-boot-info/src/main.rs
+++ b/examples/pbp/pbp-boot-info/src/main.rs
@@ -5,12 +5,13 @@ use artinchip_hal::gtc::CntFreq;
 use artinchip_hal::prelude::*;
 use artinchip_hal::uart::*;
 use artinchip_hal::wdog::RegWrMode;
-use artinchip_rt::{Peripherals, pbp_entry};
+use artinchip_rt::{Peripherals, pbp_entry, prelude::*};
 use embedded_io::Write;
 use panic_halt as _;
 
 #[pbp_entry]
-fn pbp_main(_boot_param: u32, _private_data: &[u8]) {
+fn pbp_main(boot_param: BootParam, _private_data: &[u8]) {
+    check_startup(&boot_param);
     let mut p = Peripherals::take();
     let tx = p.gpioa.pa0.into_uart0_tx();
     let rx = p.gpioa.pa1.into_uart0_rx();

--- a/examples/pbp/pbp-dma/Cargo.toml
+++ b/examples/pbp/pbp-dma/Cargo.toml
@@ -8,8 +8,10 @@ panic-halt = "1.0.0"
 embedded-io = "0.7.1"
 artinchip-hal = { version = "0.0.0", path = "../../../artinchip-hal" }
 artinchip-rt = { version = "0.0.0", path = "../../../artinchip-rt" }
+log = { version = "0.4", default-features = false }
 
 [features]
-default = ["d13x"]
+default = ["d13x", "logger"]
+logger = ["artinchip-hal/uart-logger"]
 d13x = ["artinchip-rt/d13x", "artinchip-hal/d13x"]
 # TODO other features for all the chips.

--- a/examples/pbp/pbp-dma/src/main.rs
+++ b/examples/pbp/pbp-dma/src/main.rs
@@ -7,7 +7,7 @@ use artinchip_hal::prelude::*;
 use artinchip_hal::uart::*;
 use artinchip_rt::prelude::*;
 use artinchip_rt::{Peripherals, pbp_entry};
-use embedded_io::Write;
+use log::info;
 use panic_halt as _;
 
 #[repr(C, align(8))]
@@ -26,9 +26,7 @@ fn pbp_main(boot_param: BootParam, _private_data: &[u8]) {
     let mut pa5 = p.gpioa.pa5.into_pull_up_output();
     let mut delay = p.gtc.new_timer_delay(CntFreq::Freq4M, &mut p.cmu);
 
-    let mut uart0 = p
-        .uart0
-        .new_blocking(tx, rx, UartConfig::default(), &mut p.cmu);
+    let _uart0 = uart_logger_init(p.uart0, tx, rx, UartConfig::default(), &mut p.cmu).unwrap();
 
     let dma_channels = p.dma.split(&mut p.cmu);
 
@@ -71,13 +69,13 @@ fn pbp_main(boot_param: BootParam, _private_data: &[u8]) {
         v_next: None,
     };
 
-    writeln!(uart0, "=== MEM2MEM DMA Task ===").ok();
-    writeln!(uart0, "Task addr: 0x{:08X}:", task as *const _ as u32).ok();
-    writeln!(uart0, "Task src addr: 0x{:08X}", task.src).ok();
-    writeln!(uart0, "Task dst addr: 0x{:08X}", task.dst).ok();
-    writeln!(uart0, "src addr % 8 = {}", task.src % 8).ok();
-    writeln!(uart0, "dst addr % 8 = {}", task.dst % 8).ok();
-    writeln!(uart0, "task.len = {}", task.len).ok();
+    info!("=== MEM2MEM DMA Task ===");
+    info!("Task addr: 0x{:08X}:", task as *const _ as u32);
+    info!("Task src addr: 0x{:08X}", task.src);
+    info!("Task dst addr: 0x{:08X}", task.dst);
+    info!("src addr % 8 = {}", task.src % 8);
+    info!("dst addr % 8 = {}", task.dst % 8);
+    info!("task.len = {}", task.len);
 
     unsafe {
         // Clean the task descriptor itself as well as the source buffer.
@@ -85,7 +83,7 @@ fn pbp_main(boot_param: BootParam, _private_data: &[u8]) {
         dcache_clean_invalidate_range(task.src as usize, task.len as usize);
     }
 
-    writeln!(uart0, "Starting DMA transfer...").ok();
+    info!("Starting DMA transfer...");
 
     dma_ch0.start(task);
 
@@ -99,25 +97,25 @@ fn pbp_main(boot_param: BootParam, _private_data: &[u8]) {
         dcache_invalidate_range(task.dst as usize, task.len as usize);
     }
 
-    writeln!(uart0, "Transfer completed!").ok();
-    writeln!(uart0, "Verify data").ok();
+    info!("Transfer completed!");
+    info!("Verify data");
 
-    writeln!(uart0, "Destination data:").ok();
+    info!("Destination data:");
     let mut test_ok = true;
     for i in 0..2000 {
         let got = unsafe { MEM_DST.0[i] };
         let expect = unsafe { MEM_SRC.0[i] };
         if got != expect {
             test_ok = false;
-            writeln!(uart0, "0x{:08X} (expected: 0x{:08X})", got, expect).ok();
+            info!("0x{:08X} (expected: 0x{:08X})", got, expect);
             continue;
         }
         if i % 200 == 0 {
-            writeln!(uart0, "0x{:08X} (expected: 0x{:08X})", got, expect).ok();
+            info!("0x{:08X} (expected: 0x{:08X})", got, expect);
         }
     }
 
-    writeln!(uart0, "Test {}", if test_ok { "PASSED" } else { "FAILED" }).ok();
+    info!("Test {}", if test_ok { "PASSED" } else { "FAILED" });
 
     loop {
         pa5.toggle();

--- a/examples/pbp/pbp-dma/src/main.rs
+++ b/examples/pbp/pbp-dma/src/main.rs
@@ -6,7 +6,7 @@ use artinchip_hal::gtc::CntFreq;
 use artinchip_hal::prelude::*;
 use artinchip_hal::uart::*;
 use artinchip_rt::prelude::*;
-use artinchip_rt::{Peripherals, core::cache::*, pbp_entry};
+use artinchip_rt::{Peripherals, pbp_entry};
 use embedded_io::Write;
 use panic_halt as _;
 
@@ -17,7 +17,8 @@ static mut MEM_SRC: MemBuf = MemBuf([0u32; 2000]);
 static mut MEM_DST: MemBuf = MemBuf([0xDEAD_BEEFu32; 2000]);
 
 #[pbp_entry]
-fn pbp_main(_boot_param: u32, _private_data: &[u8]) {
+fn pbp_main(boot_param: BootParam, _private_data: &[u8]) {
+    check_startup(&boot_param);
     let mut p = Peripherals::take();
 
     let tx = p.gpioa.pa0.into_uart0_tx();

--- a/examples/pbp/pbp-flash/Cargo.toml
+++ b/examples/pbp/pbp-flash/Cargo.toml
@@ -11,8 +11,10 @@ embedded-hal = "1.0.0"
 artinchip-hal = { version = "0.0.0", path = "../../../artinchip-hal" }
 artinchip-rt = { version = "0.0.0", path = "../../../artinchip-rt" }
 w25qxxxjv = { git = "https://github.com/CosmoBunny/w25qxxxjv.git", branch = "main" }
+log = { version = "0.4", default-features = false }
 
 [features]
-default = ["d13x"]
+default = ["d13x", "logger"]
+logger = ["artinchip-hal/uart-logger"]
 d13x = ["artinchip-rt/d13x", "artinchip-hal/d13x"]
 # TODO other features for all the chips.

--- a/examples/pbp/pbp-flash/src/main.rs
+++ b/examples/pbp/pbp-flash/src/main.rs
@@ -13,7 +13,8 @@ use panic_halt as _;
 use w25qxxxjv::{Model, SpiSpeed, W25QXXXJV};
 
 #[pbp_entry]
-fn pbp_main(_boot_param: u32, _private_data: &[u8]) {
+fn pbp_main(boot_param: BootParam, _private_data: &[u8]) {
+    check_startup(&boot_param);
     let mut p = Peripherals::take();
 
     let tx = p.gpioa.pa0.into_uart0_tx();

--- a/examples/pbp/pbp-flash/src/main.rs
+++ b/examples/pbp/pbp-flash/src/main.rs
@@ -8,6 +8,7 @@ use artinchip_hal::uart::*;
 use artinchip_rt::prelude::*;
 use artinchip_rt::{Peripherals, pbp_entry};
 use embedded_io::Write;
+use log::{error, info};
 use panic_halt as _;
 
 use w25qxxxjv::{Model, SpiSpeed, W25QXXXJV};
@@ -19,9 +20,7 @@ fn pbp_main(boot_param: BootParam, _private_data: &[u8]) {
 
     let tx = p.gpioa.pa0.into_uart0_tx();
     let rx = p.gpioa.pa1.into_uart0_rx();
-    let mut uart0 = p
-        .uart0
-        .new_blocking(tx, rx, UartConfig::default(), &mut p.cmu);
+    let mut uart0 = uart_logger_init(p.uart0, tx, rx, UartConfig::default(), &mut p.cmu).unwrap();
 
     let mut led = p.gpioa.pa5.into_pull_up_output();
     let mut delay = p.gtc.new_timer_delay(CntFreq::Freq4M, &mut p.cmu);
@@ -40,18 +39,18 @@ fn pbp_main(boot_param: BootParam, _private_data: &[u8]) {
         None::<NoPad>,
     );
 
-    writeln!(uart0, "Welcome to pbp flash example by artinchip-hal🦀!").ok();
+    info!("Welcome to pbp flash example by artinchip-hal🦀!");
 
     let qspi0 = p
         .qspi0
         .new_blocking(qspi0_pad, QspiConfig::nor_flash(), &mut p.cmu);
 
-    writeln!(uart0, "QSPI initialized").ok();
+    info!("QSPI initialized");
 
     let mut flash = match W25QXXXJV::new(qspi0, cs, SpiSpeed::Single, Model::Q128) {
         Ok(flash) => flash,
         Err(e) => {
-            writeln!(uart0, "ERROR: Failed to initialize W25Q driver: {:?}", e).ok();
+            error!("Failed to initialize W25Q driver: {:?}", e);
             loop {
                 led.toggle().ok();
                 delay.delay_ms(200);
@@ -59,25 +58,25 @@ fn pbp_main(boot_param: BootParam, _private_data: &[u8]) {
         }
     };
 
-    writeln!(uart0, "W25Q driver created").ok();
+    info!("W25Q driver created");
     delay.delay_ms(100);
 
     match flash.manufacture_device_id() {
         Ok(id) => {
-            writeln!(uart0, "Manufacturer ID: 0x{:02X}", id[0]).ok();
-            writeln!(uart0, "Device ID:       0x{:02X}", id[1]).ok();
+            info!("Manufacturer ID: 0x{:02X}", id[0]);
+            info!("Device ID:       0x{:02X}", id[1]);
         }
         Err(e) => {
-            writeln!(uart0, "ERROR: Failed to read ID: {:?}", e).ok();
+            error!("Failed to read ID: {:?}", e);
         }
     }
 
     match flash.read_unique_id() {
         Ok(uid) => {
-            writeln!(uart0, "Unique ID: 0x{:016X}", uid).ok();
+            info!("Unique ID: 0x{:016X}", uid);
         }
         Err(e) => {
-            writeln!(uart0, "ERROR: Failed to read Unique ID: {:?}", e).ok();
+            error!("Failed to read Unique ID: {:?}", e);
         }
     }
 
@@ -86,7 +85,7 @@ fn pbp_main(boot_param: BootParam, _private_data: &[u8]) {
     // Read first 64 bytes from flash
     match flash.read_data(0x0000, &mut read_buf) {
         Ok(_) => {
-            writeln!(uart0, "First 64 bytes from flash:").ok();
+            info!("First 64 bytes from flash:");
 
             // Print 64 bytes, 16 bytes per line
             for i in 0..4 {
@@ -101,7 +100,7 @@ fn pbp_main(boot_param: BootParam, _private_data: &[u8]) {
             let mut magic_num = [0u8; 4];
             match flash.read_data(0x0, &mut magic_num) {
                 Ok(_) => {
-                    writeln!(uart0, "Magic number1(expected: \"AIC\"):").ok();
+                    info!("Magic number1(expected: \"AIC \"):");
                     write!(uart0, "\"").ok();
                     for i in 0..4 {
                         write!(uart0, "{}", magic_num[i] as char).ok();
@@ -109,12 +108,12 @@ fn pbp_main(boot_param: BootParam, _private_data: &[u8]) {
                     writeln!(uart0, "\"").ok();
                 }
                 Err(e) => {
-                    writeln!(uart0, "ERROR: Failed to read magic number1: {:?}", e).ok();
+                    error!("Failed to read magic number1: {:?}", e);
                 }
             }
             match flash.read_data(0x100, &mut magic_num) {
                 Ok(_) => {
-                    writeln!(uart0, "Magic number2(expected: \"PBP\"):").ok();
+                    info!("Magic number2(expected: \"PBP \"):");
                     write!(uart0, "\"").ok();
                     for i in 0..4 {
                         write!(uart0, "{}", magic_num[i] as char).ok();
@@ -122,16 +121,16 @@ fn pbp_main(boot_param: BootParam, _private_data: &[u8]) {
                     writeln!(uart0, "\"").ok();
                 }
                 Err(e) => {
-                    writeln!(uart0, "ERROR: Failed to read magic number2: {:?}", e).ok();
+                    error!("Failed to read magic number2: {:?}", e);
                 }
             }
         }
         Err(e) => {
-            writeln!(uart0, "ERROR: Failed to read flash: {:?}", e).ok();
+            error!("Failed to read flash: {:?}", e);
         }
     }
 
-    writeln!(uart0, "Tests complete").ok();
+    info!("Tests complete");
 
     loop {
         led.toggle().ok();

--- a/examples/pbp/pbp-hello-world/Cargo.toml
+++ b/examples/pbp/pbp-hello-world/Cargo.toml
@@ -8,8 +8,10 @@ panic-halt = "1.0.0"
 embedded-io = "0.7.1"
 artinchip-hal = { version = "0.0.0", path = "../../../artinchip-hal" }
 artinchip-rt = { version = "0.0.0", path = "../../../artinchip-rt" }
+log = { version = "0.4", default-features = false }
 
 [features]
-default = ["d13x"]
+default = ["d13x", "logger"]
+logger = ["artinchip-hal/uart-logger"]
 d13x = ["artinchip-rt/d13x", "artinchip-hal/d13x"]
 # TODO other features for all the chips.

--- a/examples/pbp/pbp-hello-world/src/main.rs
+++ b/examples/pbp/pbp-hello-world/src/main.rs
@@ -3,13 +3,13 @@
 
 use artinchip_hal::prelude::*;
 use artinchip_hal::uart::*;
-use artinchip_rt::prelude::*;
-use artinchip_rt::{Peripherals, pbp_entry};
+use artinchip_rt::{Peripherals, pbp_entry, prelude::*};
 use embedded_io::Write;
 use panic_halt as _;
 
 #[pbp_entry]
-fn pbp_main(_boot_param: u32, _private_data: &[u8]) {
+fn pbp_main(boot_param: BootParam, _private_data: &[u8]) {
+    check_startup(&boot_param);
     let mut p = Peripherals::take();
     let tx = p.gpioa.pa0.into_uart0_tx();
     let rx = p.gpioa.pa1.into_uart0_rx();

--- a/examples/pbp/pbp-hello-world/src/main.rs
+++ b/examples/pbp/pbp-hello-world/src/main.rs
@@ -4,7 +4,7 @@
 use artinchip_hal::prelude::*;
 use artinchip_hal::uart::*;
 use artinchip_rt::{Peripherals, pbp_entry, prelude::*};
-use embedded_io::Write;
+use log::info;
 use panic_halt as _;
 
 #[pbp_entry]
@@ -15,18 +15,12 @@ fn pbp_main(boot_param: BootParam, _private_data: &[u8]) {
     let rx = p.gpioa.pa1.into_uart0_rx();
     let mut pa5 = p.gpioa.pa5.into_pull_up_input();
 
-    let mut uart0 = p
-        .uart0
-        .new_blocking(tx, rx, UartConfig::default(), &mut p.cmu);
+    let _uart0 = uart_logger_init(p.uart0, tx, rx, UartConfig::default(), &mut p.cmu).unwrap();
 
-    writeln!(
-        uart0,
-        "Welcome to pbp hello world example by artinchip-hal🦀!"
-    )
-    .ok();
+    info!("Welcome to pbp hello world example by artinchip-hal🦀!");
     loop {
         if pa5.is_low().unwrap_or(false) {
-            writeln!(uart0, "Button pressed!").ok();
+            info!("Button pressed!");
             while pa5.is_low().unwrap_or(false) {
                 // wait for button to release
                 core::hint::spin_loop();

--- a/examples/pbp/pbp-i2c-master/Cargo.toml
+++ b/examples/pbp/pbp-i2c-master/Cargo.toml
@@ -8,8 +8,10 @@ panic-halt = "1.0.0"
 embedded-io = "0.7.1"
 artinchip-hal = { version = "0.0.0", path = "../../../artinchip-hal" }
 artinchip-rt = { version = "0.0.0", path = "../../../artinchip-rt" }
+log = { version = "0.4", default-features = false }
 
 [features]
-default = ["d13x"]
+default = ["d13x", "logger"]
+logger = ["artinchip-hal/uart-logger"]
 d13x = ["artinchip-rt/d13x", "artinchip-hal/d13x"]
 # TODO other features for all the chips.

--- a/examples/pbp/pbp-i2c-master/src/main.rs
+++ b/examples/pbp/pbp-i2c-master/src/main.rs
@@ -7,7 +7,7 @@ use artinchip_hal::prelude::*;
 use artinchip_hal::uart::*;
 use artinchip_rt::prelude::*;
 use artinchip_rt::{Peripherals, pbp_entry};
-use embedded_io::Write;
+use log::{error, info};
 use panic_halt as _;
 
 #[pbp_entry]
@@ -26,19 +26,13 @@ fn pbp_main(boot_param: BootParam, _private_data: &[u8]) {
 
     let mut delay = p.gtc.new_timer_delay(CntFreq::Freq4M, &mut p.cmu);
 
-    let mut uart0 = p
-        .uart0
-        .new_blocking(tx, rx, UartConfig::default(), &mut p.cmu);
+    let _uart0 = uart_logger_init(p.uart0, tx, rx, UartConfig::default(), &mut p.cmu).unwrap();
 
     let mut i2c2 = p
         .i2c2
         .new_blocking((scl, sda), I2cConfig::default(), &mut p.cmu);
 
-    writeln!(
-        uart0,
-        "Welcome to pbp i2c master example by artinchip-hal🦀!"
-    )
-    .ok();
+    info!("Welcome to pbp i2c master example by artinchip-hal🦀!");
 
     // Ensure rst and int pins are low
     touch_rst.set_low().ok();
@@ -46,36 +40,34 @@ fn pbp_main(boot_param: BootParam, _private_data: &[u8]) {
     delay.delay_ms(10);
 
     // Initialize GT911 address
-    writeln!(uart0, "Initializing GT911 address... ").ok();
+    info!("Initializing GT911 address... ");
     touch_int.set_high().ok();
     delay.delay_us(110);
     touch_rst.set_high().ok();
     delay.delay_ms(50);
 
-    writeln!(uart0, "GT911 initialized, address is 0x14").ok();
+    info!("GT911 initialized, address is 0x14");
 
     loop {
         if button.is_low().unwrap_or(false) {
             // Wait for button release
             while button.is_low().unwrap_or(false) {}
 
-            writeln!(uart0, "Button pressed!  Reading ID_REG from GT911...").ok();
+            info!("Button pressed!  Reading ID_REG from GT911...");
 
             let mut id_val = [0u8; 4];
             match i2c2.write_read(0x14u8, &[0x81, 0x40], &mut id_val) {
                 Ok(_) => {
                     if let Ok(s) = core::str::from_utf8(&id_val) {
-                        writeln!(uart0, "ID:  {}", s).ok();
+                        info!("ID:  {}", s);
                     }
-                    writeln!(
-                        uart0,
+                    info!(
                         "Bytes:  {:02X} {:02X} {:02X} {:02X}",
                         id_val[0], id_val[1], id_val[2], id_val[3]
-                    )
-                    .ok();
+                    );
                 }
                 Err(_) => {
-                    writeln!(uart0, "Failed to read ID! ").ok();
+                    error!("Failed to read ID! ");
                 }
             }
 

--- a/examples/pbp/pbp-i2c-master/src/main.rs
+++ b/examples/pbp/pbp-i2c-master/src/main.rs
@@ -19,8 +19,6 @@ fn pbp_main(boot_param: BootParam, _private_data: &[u8]) {
     let scl = p.gpioa.pa8.into_i2c2_scl();
     let sda = p.gpioa.pa9.into_i2c2_sda();
 
-    let mut button = p.gpioa.pa5.into_pull_up_input();
-
     let mut touch_rst = p.gpioa.pa10.into_pull_up_output();
     let mut touch_int = p.gpioa.pa11.into_pull_up_output();
 
@@ -46,44 +44,29 @@ fn pbp_main(boot_param: BootParam, _private_data: &[u8]) {
     touch_rst.set_high().ok();
     delay.delay_ms(50);
 
-    info!("GT911 initialized, address is 0x14");
+    info!("Trying to read GT911 ID... ");
 
-    loop {
-        if button.is_low().unwrap_or(false) {
-            // Wait for button release
-            while button.is_low().unwrap_or(false) {}
-
-            info!("Button pressed!  Reading ID_REG from GT911...");
-
-            let mut id_val = [0u8; 4];
-            match i2c2.write_read(0x14u8, &[0x81, 0x40], &mut id_val) {
-                Ok(_) => {
-                    if let Ok(s) = core::str::from_utf8(&id_val) {
-                        info!("ID:  {}", s);
-                    }
-                    info!(
-                        "Bytes:  {:02X} {:02X} {:02X} {:02X}",
-                        id_val[0], id_val[1], id_val[2], id_val[3]
-                    );
+    let mut max_tries = 5;
+    let mut id_val = [0u8; 4];
+    while max_tries > 0 {
+        match i2c2.write_read(0x14u8, &[0x81, 0x40], &mut id_val) {
+            Ok(_) => {
+                if let Ok(s) = core::str::from_utf8(&id_val) {
+                    info!("ID:  {}", s);
                 }
-                Err(_) => {
-                    error!("Failed to read ID! ");
-                }
+                info!(
+                    "Bytes:  {:02X} {:02X} {:02X} {:02X}",
+                    id_val[0], id_val[1], id_val[2], id_val[3]
+                );
+                delay.delay_ms(100);
+                break;
             }
-
-            // Set pa5 to output mode and blink LED 3 times
-            let pa5 = button.free();
-            let mut led = pa5.into_pull_up_output();
-            for _ in 0..3 {
-                led.toggle().ok();
-                delay.delay_ms(50);
-                led.toggle().ok();
-                delay.delay_ms(50);
+            Err(e) => {
+                error!("Failed to read GT911 ID! ({:?})", e);
+                max_tries -= 1;
             }
-
-            // Set pa5 back to input mode
-            let pa5 = led.free();
-            button = pa5.into_pull_up_input();
         }
     }
+
+    loop {}
 }

--- a/examples/pbp/pbp-i2c-master/src/main.rs
+++ b/examples/pbp/pbp-i2c-master/src/main.rs
@@ -11,7 +11,8 @@ use embedded_io::Write;
 use panic_halt as _;
 
 #[pbp_entry]
-fn pbp_main(_boot_param: u32, _private_data: &[u8]) {
+fn pbp_main(boot_param: BootParam, _private_data: &[u8]) {
+    check_startup(&boot_param);
     let mut p = Peripherals::take();
     let tx = p.gpioa.pa0.into_uart0_tx();
     let rx = p.gpioa.pa1.into_uart0_rx();

--- a/examples/pbp/pbp-pwm/Cargo.toml
+++ b/examples/pbp/pbp-pwm/Cargo.toml
@@ -9,8 +9,10 @@ embedded-io = "0.7.1"
 embedded-time = "0.12.1"
 artinchip-hal = { version = "0.0.0", path = "../../../artinchip-hal" }
 artinchip-rt = { version = "0.0.0", path = "../../../artinchip-rt" }
+log = { version = "0.4", default-features = false }
 
 [features]
-default = ["d13x"]
+default = ["d13x", "logger"]
+logger = ["artinchip-hal/uart-logger"]
 d13x = ["artinchip-rt/d13x", "artinchip-hal/d13x"]
 # TODO other features for all the chips.

--- a/examples/pbp/pbp-pwm/src/main.rs
+++ b/examples/pbp/pbp-pwm/src/main.rs
@@ -5,8 +5,8 @@ use artinchip_hal::prelude::*;
 use artinchip_hal::pwm::*;
 use artinchip_hal::uart::*;
 use artinchip_rt::{Peripherals, pbp_entry, prelude::*};
-use embedded_io::Write;
 use embedded_time::rate::Hertz;
+use log::info;
 use panic_halt as _;
 
 #[pbp_entry]
@@ -16,11 +16,9 @@ fn pbp_main(boot_param: BootParam, _private_data: &[u8]) {
     let tx = p.gpioa.pa0.into_uart0_tx();
     let rx = p.gpioa.pa1.into_uart0_rx();
 
-    let mut uart0 = p
-        .uart0
-        .new_blocking(tx, rx, UartConfig::default(), &mut p.cmu);
+    let _uart0 = uart_logger_init(p.uart0, tx, rx, UartConfig::default(), &mut p.cmu);
 
-    writeln!(uart0, "Welcome to pbp pwm example by artinchip-hal🦀!").ok();
+    info!("Welcome to pbp pwm example by artinchip-hal🦀!");
 
     let pwm_pina = p.gpioe.pe16.into_pwm_ch3_a();
     let pwm_pinb = p.gpioe.pe17.into_pwm_ch3_b();
@@ -30,22 +28,18 @@ fn pbp_main(boot_param: BootParam, _private_data: &[u8]) {
         &mut p.cmu,
     );
     pwm_ch3.set_freq_and_ratio(Hertz::new(1_000), 40.0, 20.0);
-    writeln!(
-        uart0,
+    info!(
         "PWM frequency: {} Hz, duty cycle a: {}%, duty cycle b: {}%",
         pwm_ch3.freq_and_ratio().0,
         pwm_ch3.freq_and_ratio().1,
         pwm_ch3.freq_and_ratio().2
-    )
-    .ok();
-    writeln!(
-        uart0,
+    );
+    info!(
         "PWM period: {} ns, duty time a: {} ns, duty time b: {} ns",
         pwm_ch3.period_and_duty().0,
         pwm_ch3.period_and_duty().1,
         pwm_ch3.period_and_duty().2
-    )
-    .ok();
+    );
     pwm_ch3.enable();
 
     loop {}

--- a/examples/pbp/pbp-pwm/src/main.rs
+++ b/examples/pbp/pbp-pwm/src/main.rs
@@ -4,13 +4,14 @@
 use artinchip_hal::prelude::*;
 use artinchip_hal::pwm::*;
 use artinchip_hal::uart::*;
-use artinchip_rt::{Peripherals, pbp_entry};
+use artinchip_rt::{Peripherals, pbp_entry, prelude::*};
 use embedded_io::Write;
 use embedded_time::rate::Hertz;
 use panic_halt as _;
 
 #[pbp_entry]
-fn pbp_main(_boot_param: u32, _private_data: &[u8]) {
+fn pbp_main(boot_param: BootParam, _private_data: &[u8]) {
+    check_startup(&boot_param);
     let mut p = Peripherals::take();
     let tx = p.gpioa.pa0.into_uart0_tx();
     let rx = p.gpioa.pa1.into_uart0_rx();


### PR DESCRIPTION
- Add UART logger module with uart-logger feature for log crate integration, replacing writeln! across all PBP examples.
- Introduce custom error types (I2cError, QspiError, UartError) with Timeout variant for blocking I2C/QSPI/UART operations, and implement timeout loops to prevent infinite hangs.
- Support BOOT-pin triggered USB upgrade mode on E907 series via `check_e907_upg_req` and `jump_to_e907_upg_entry`.
- Rename feature clic_interrupts to clic-interrupts for consistency across Cargo.toml and code.
- Adjust CLIC vector table size to 100 entries (from 128), add default interrupt handler with error logging, and improve trap handler diagnostics.
- Enhance async UART reliability by draining RX FIFO and waiting for TX idle after cold boot to avoid data loss.
- Parse BootROM parameters with new BootParam type and add boot info printing in examples.
- Update pbp_entry macro signature to accept only `BootParam` and include prelude re-exports.

`pbp-async-uart` tested on Hengshan pi v1.2, I used the illegal instruction below to test whether the log function of the DefaultTraphandler is working properly.

```rust
unsafe {
    core::arch::asm!(".insn 0xffffffff", options(nomem, nostack));
}
```

<img width="1108" height="888" alt="ecd46619040220c18f38e3d324187a70" src="https://github.com/user-attachments/assets/982ddcb9-35fc-4c02-8b5f-6ef38caa2fd2" />
<img width="1097" height="537" alt="143d84f2de0323f714f0b38f79e7964b" src="https://github.com/user-attachments/assets/5f774406-d85b-4d2c-b5d9-57bd3b8ec5ea" />
